### PR TITLE
Add structural section property calculator tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import FigureLayoutApp from './components/figure/FigureLayoutApp';
 import PDFConverterApp from './components/pdf/PDFConverterApp';
 import MarkdownEditor from './components/markdown/MarkdownEditor';
 import BoringDataApp from './components/boring/BoringDataApp';
+import SectionPropertyCalculator from './components/section/SectionPropertyCalculator';
 import Toast from './components/common/Toast';
 import { useToast } from './hooks/useToast';
 import { useTheme } from './hooks/useTheme';
@@ -25,6 +26,7 @@ function App() {
     if (pathname === '/pdf') return 'pdf';
     if (pathname === '/markdown') return 'markdown';
     if (pathname === '/boring') return 'boring';
+    if (pathname === '/section') return 'section';
     return 'matrix'; // デフォルトは matrix
   };
 
@@ -32,7 +34,7 @@ function App() {
 
   // ルートパスまたは未定義パスの場合は /matrix にリダイレクト
   useEffect(() => {
-    const validPaths = ['/', '/matrix', '/figure', '/pdf', '/markdown', '/boring'];
+    const validPaths = ['/', '/matrix', '/figure', '/pdf', '/markdown', '/boring', '/section'];
     if (!validPaths.includes(location.pathname)) {
       navigate('/matrix', { replace: true });
     } else if (location.pathname === '/') {
@@ -70,6 +72,9 @@ function App() {
             onSuccess={showSuccess}
             onError={showError}
           />
+        </div>
+        <div style={{ display: activeTab === 'section' ? 'block' : 'none' }}>
+          <SectionPropertyCalculator />
         </div>
       </AppLayout>
 

--- a/src/components/common/Navigation.tsx
+++ b/src/components/common/Navigation.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Calculator, Image, FileText, PenLine, MapPin, Menu, X } from 'lucide-react';
+import { Calculator, Image, FileText, PenLine, MapPin, Menu, X, Ruler } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import type { AppTab } from '../../types';
 
@@ -14,6 +14,7 @@ const navItems: { tab: AppTab; path: string; icon: React.ComponentType<{ classNa
   { tab: 'pdf', path: '/pdf', icon: FileText, label: 'PDF Converter' },
   { tab: 'markdown', path: '/markdown', icon: PenLine, label: 'Markdown Editor' },
   { tab: 'boring', path: '/boring', icon: MapPin, label: 'Boring Data' },
+  { tab: 'section', path: '/section', icon: Ruler, label: 'Section Calc' },
 ];
 
 const Navigation: React.FC<NavigationProps> = ({ activeTab }) => {

--- a/src/components/section/DimensionInputs.tsx
+++ b/src/components/section/DimensionInputs.tsx
@@ -24,20 +24,28 @@ const InputField: React.FC<InputFieldProps> = ({
   unit = 'mm',
   min = 0,
   step = 1,
-}) => (
-  <div className="flex items-center gap-2">
-    <label className="w-24 text-sm text-gray-700 dark:text-gray-300">{label}</label>
-    <input
-      type="number"
-      value={value ?? ''}
-      onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
-      min={min}
-      step={step}
-      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
-    />
-    <span className="w-8 text-sm text-gray-500 dark:text-gray-400">{unit}</span>
-  </div>
-);
+}) => {
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    // フォーカス時に全選択（新しい入力で上書きできるように）
+    e.target.select();
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label className="w-24 text-sm text-gray-700 dark:text-gray-300">{label}</label>
+      <input
+        type="number"
+        value={value ?? ''}
+        onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+        onFocus={handleFocus}
+        min={min}
+        step={step}
+        className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+      />
+      <span className="w-8 text-sm text-gray-500 dark:text-gray-400">{unit}</span>
+    </div>
+  );
+};
 
 const DimensionInputs: React.FC<DimensionInputsProps> = ({
   shapeType,

--- a/src/components/section/DimensionInputs.tsx
+++ b/src/components/section/DimensionInputs.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import type { SectionShapeType, SectionDimensions } from '../../types';
+
+interface DimensionInputsProps {
+  shapeType: SectionShapeType;
+  dimensions: SectionDimensions;
+  onUpdate: (key: keyof SectionDimensions, value: number) => void;
+  validationErrors: string[];
+}
+
+interface InputFieldProps {
+  label: string;
+  value: number | undefined;
+  onChange: (value: number) => void;
+  unit?: string;
+  min?: number;
+  step?: number;
+}
+
+const InputField: React.FC<InputFieldProps> = ({
+  label,
+  value,
+  onChange,
+  unit = 'mm',
+  min = 0,
+  step = 1,
+}) => (
+  <div className="flex items-center gap-2">
+    <label className="w-24 text-sm text-gray-700 dark:text-gray-300">{label}</label>
+    <input
+      type="number"
+      value={value ?? ''}
+      onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+      min={min}
+      step={step}
+      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+    />
+    <span className="w-8 text-sm text-gray-500 dark:text-gray-400">{unit}</span>
+  </div>
+);
+
+const DimensionInputs: React.FC<DimensionInputsProps> = ({
+  shapeType,
+  dimensions,
+  onUpdate,
+  validationErrors,
+}) => {
+  const renderInputs = () => {
+    switch (shapeType) {
+      case 'circle':
+        return (
+          <InputField
+            label="直径 D"
+            value={dimensions.diameter}
+            onChange={(v) => onUpdate('diameter', v)}
+          />
+        );
+
+      case 'pipe':
+        return (
+          <>
+            <InputField
+              label="外径 D"
+              value={dimensions.outerDiameter}
+              onChange={(v) => onUpdate('outerDiameter', v)}
+            />
+            <InputField
+              label="内径 d"
+              value={dimensions.innerDiameter}
+              onChange={(v) => onUpdate('innerDiameter', v)}
+            />
+          </>
+        );
+
+      case 'rectangle':
+        return (
+          <>
+            <InputField
+              label="幅 B"
+              value={dimensions.width}
+              onChange={(v) => onUpdate('width', v)}
+            />
+            <InputField
+              label="高さ H"
+              value={dimensions.height}
+              onChange={(v) => onUpdate('height', v)}
+            />
+          </>
+        );
+
+      case 'box':
+        return (
+          <>
+            <InputField
+              label="外幅 B"
+              value={dimensions.outerWidth}
+              onChange={(v) => onUpdate('outerWidth', v)}
+            />
+            <InputField
+              label="外高さ H"
+              value={dimensions.outerHeight}
+              onChange={(v) => onUpdate('outerHeight', v)}
+            />
+            <InputField
+              label="板厚 t"
+              value={dimensions.thickness}
+              onChange={(v) => onUpdate('thickness', v)}
+              step={0.1}
+            />
+          </>
+        );
+
+      case 'h-beam':
+        return (
+          <>
+            <InputField
+              label="フランジ幅 B"
+              value={dimensions.flangeWidth}
+              onChange={(v) => onUpdate('flangeWidth', v)}
+            />
+            <InputField
+              label="ウェブ高さ H"
+              value={dimensions.webHeight}
+              onChange={(v) => onUpdate('webHeight', v)}
+            />
+            <InputField
+              label="フランジ厚 tf"
+              value={dimensions.flangeThickness}
+              onChange={(v) => onUpdate('flangeThickness', v)}
+              step={0.1}
+            />
+            <InputField
+              label="ウェブ厚 tw"
+              value={dimensions.webThickness}
+              onChange={(v) => onUpdate('webThickness', v)}
+              step={0.1}
+            />
+          </>
+        );
+
+      case 'l-angle':
+        return (
+          <>
+            <InputField
+              label="辺 A"
+              value={dimensions.legA}
+              onChange={(v) => onUpdate('legA', v)}
+            />
+            <InputField
+              label="辺 B"
+              value={dimensions.legB}
+              onChange={(v) => onUpdate('legB', v)}
+            />
+            <InputField
+              label="厚さ t"
+              value={dimensions.legThickness}
+              onChange={(v) => onUpdate('legThickness', v)}
+              step={0.1}
+            />
+          </>
+        );
+
+      case 'channel':
+        return (
+          <>
+            <InputField
+              label="幅 B"
+              value={dimensions.channelWidth}
+              onChange={(v) => onUpdate('channelWidth', v)}
+            />
+            <InputField
+              label="高さ H"
+              value={dimensions.channelHeight}
+              onChange={(v) => onUpdate('channelHeight', v)}
+            />
+            <InputField
+              label="フランジ厚 tf"
+              value={dimensions.channelFlangeThickness}
+              onChange={(v) => onUpdate('channelFlangeThickness', v)}
+              step={0.1}
+            />
+            <InputField
+              label="ウェブ厚 tw"
+              value={dimensions.channelWebThickness}
+              onChange={(v) => onUpdate('channelWebThickness', v)}
+              step={0.1}
+            />
+          </>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
+        寸法入力
+      </h3>
+      <div className="space-y-3">
+        {renderInputs()}
+      </div>
+      {validationErrors.length > 0 && (
+        <div className="mt-3 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md">
+          {validationErrors.map((error, i) => (
+            <p key={i} className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DimensionInputs;

--- a/src/components/section/ResultsDisplay.tsx
+++ b/src/components/section/ResultsDisplay.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import type { SectionProperties, SectionShapeType } from '../../types';
+
+interface ResultsDisplayProps {
+  properties: SectionProperties | null;
+  shapeType: SectionShapeType;
+}
+
+// 数値フォーマット（有効数字4桁）
+function formatNumber(value: number): string {
+  if (value === 0) return '0';
+  if (Math.abs(value) >= 1e6) {
+    return value.toExponential(3);
+  }
+  if (Math.abs(value) >= 1000) {
+    return value.toLocaleString('ja-JP', { maximumFractionDigits: 1 });
+  }
+  if (Math.abs(value) >= 1) {
+    return value.toFixed(2);
+  }
+  return value.toPrecision(4);
+}
+
+interface ResultRowProps {
+  label: string;
+  symbol: string;
+  value: number;
+  unit: string;
+}
+
+const ResultRow: React.FC<ResultRowProps> = ({ label, symbol, value, unit }) => (
+  <div className="flex items-center justify-between py-2 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
+    <div className="flex items-center gap-2">
+      <span className="text-gray-700 dark:text-gray-300">{label}</span>
+      <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">({symbol})</span>
+    </div>
+    <div className="flex items-center gap-2">
+      <span className="font-mono font-semibold text-gray-900 dark:text-gray-100">
+        {formatNumber(value)}
+      </span>
+      <span className="text-sm text-gray-500 dark:text-gray-400 w-16 text-right">{unit}</span>
+    </div>
+  </div>
+);
+
+const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ properties, shapeType }) => {
+  if (!properties) {
+    return (
+      <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg text-center text-gray-500 dark:text-gray-400">
+        有効な寸法を入力してください
+      </div>
+    );
+  }
+
+  const showXY = shapeType !== 'circle' && shapeType !== 'pipe';
+  const showCentroid = shapeType === 'l-angle' || shapeType === 'channel';
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
+        断面性能
+      </h3>
+      <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
+        <ResultRow label="断面積" symbol="A" value={properties.area} unit="mm²" />
+
+        {showCentroid && properties.centroidX !== undefined && (
+          <ResultRow label="図心位置X" symbol="Cx" value={properties.centroidX} unit="mm" />
+        )}
+        {showCentroid && properties.centroidY !== undefined && (
+          <ResultRow label="図心位置Y" symbol="Cy" value={properties.centroidY} unit="mm" />
+        )}
+
+        <div className="mt-4 pt-2 border-t border-gray-300 dark:border-gray-600">
+          <h4 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+            断面2次モーメント
+          </h4>
+          {showXY ? (
+            <>
+              <ResultRow label="X軸周り" symbol="Ix" value={properties.momentOfInertiaX} unit="mm⁴" />
+              <ResultRow label="Y軸周り" symbol="Iy" value={properties.momentOfInertiaY} unit="mm⁴" />
+            </>
+          ) : (
+            <ResultRow label="断面2次モーメント" symbol="I" value={properties.momentOfInertiaX} unit="mm⁴" />
+          )}
+        </div>
+
+        <div className="mt-4 pt-2 border-t border-gray-300 dark:border-gray-600">
+          <h4 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+            断面係数
+          </h4>
+          {showXY ? (
+            <>
+              <ResultRow label="X軸周り" symbol="Zx" value={properties.sectionModulusX} unit="mm³" />
+              <ResultRow label="Y軸周り" symbol="Zy" value={properties.sectionModulusY} unit="mm³" />
+            </>
+          ) : (
+            <ResultRow label="断面係数" symbol="Z" value={properties.sectionModulusX} unit="mm³" />
+          )}
+        </div>
+
+        <div className="mt-4 pt-2 border-t border-gray-300 dark:border-gray-600">
+          <h4 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+            断面2次半径
+          </h4>
+          {showXY ? (
+            <>
+              <ResultRow label="X軸周り" symbol="ix" value={properties.radiusOfGyrationX} unit="mm" />
+              <ResultRow label="Y軸周り" symbol="iy" value={properties.radiusOfGyrationY} unit="mm" />
+            </>
+          ) : (
+            <ResultRow label="断面2次半径" symbol="i" value={properties.radiusOfGyrationX} unit="mm" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResultsDisplay;

--- a/src/components/section/SectionDiagram.tsx
+++ b/src/components/section/SectionDiagram.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import type { SectionShapeType, SectionDimensions, SectionProperties } from '../../types';
+
+interface SectionDiagramProps {
+  shapeType: SectionShapeType;
+  dimensions: SectionDimensions;
+  properties?: SectionProperties | null;
+}
+
+const SectionDiagram: React.FC<SectionDiagramProps> = ({ shapeType, dimensions, properties }) => {
+  const svgSize = 200;
+  const padding = 20;
+  const viewBox = `0 0 ${svgSize} ${svgSize}`;
+
+  const renderShape = () => {
+    switch (shapeType) {
+      case 'circle':
+        return renderCircle();
+      case 'pipe':
+        return renderPipe();
+      case 'rectangle':
+        return renderRectangle();
+      case 'box':
+        return renderBox();
+      case 'h-beam':
+        return renderHBeam();
+      case 'l-angle':
+        return renderLAngle();
+      case 'channel':
+        return renderChannel();
+      default:
+        return null;
+    }
+  };
+
+  const renderCircle = () => {
+    const D = dimensions.diameter || 100;
+    const r = (svgSize - padding * 2) / 2;
+    const cx = svgSize / 2;
+    const cy = svgSize / 2;
+
+    return (
+      <g>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400"
+          strokeWidth="2"
+        />
+        {/* 直径寸法線 */}
+        <line x1={cx - r} y1={cy} x2={cx + r} y2={cy}
+          className="stroke-gray-600 dark:stroke-gray-400" strokeWidth="1" strokeDasharray="4" />
+        <text x={cx} y={cy - 10} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">D={D}</text>
+      </g>
+    );
+  };
+
+  const renderPipe = () => {
+    const D = dimensions.outerDiameter || 100;
+    const d = dimensions.innerDiameter || 80;
+    const scale = (svgSize - padding * 2) / D;
+    const cx = svgSize / 2;
+    const cy = svgSize / 2;
+    const rOuter = (D * scale) / 2;
+    const rInner = (d * scale) / 2;
+
+    return (
+      <g>
+        <circle cx={cx} cy={cy} r={rOuter}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        <circle cx={cx} cy={cy} r={rInner}
+          className="fill-white dark:fill-gray-800 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        <line x1={cx - rOuter} y1={cy} x2={cx + rOuter} y2={cy}
+          className="stroke-gray-600 dark:stroke-gray-400" strokeWidth="1" strokeDasharray="4" />
+        <text x={cx} y={cy - rOuter - 5} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">D={D}</text>
+        <text x={cx} y={cy + 15} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">d={d}</text>
+      </g>
+    );
+  };
+
+  const renderRectangle = () => {
+    const B = dimensions.width || 100;
+    const H = dimensions.height || 200;
+    const maxDim = Math.max(B, H);
+    const scale = (svgSize - padding * 2) / maxDim;
+    const w = B * scale;
+    const h = H * scale;
+    const x = (svgSize - w) / 2;
+    const y = (svgSize - h) / 2;
+
+    return (
+      <g>
+        <rect x={x} y={y} width={w} height={h}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        {/* 寸法表示 */}
+        <text x={x + w / 2} y={y - 5} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">B={B}</text>
+        <text x={x + w + 10} y={y + h / 2} textAnchor="start"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">H={H}</text>
+      </g>
+    );
+  };
+
+  const renderBox = () => {
+    const B = dimensions.outerWidth || 100;
+    const H = dimensions.outerHeight || 200;
+    const t = dimensions.thickness || 10;
+    const maxDim = Math.max(B, H);
+    const scale = (svgSize - padding * 2) / maxDim;
+    const wOuter = B * scale;
+    const hOuter = H * scale;
+    const wInner = (B - 2 * t) * scale;
+    const hInner = (H - 2 * t) * scale;
+    const x = (svgSize - wOuter) / 2;
+    const y = (svgSize - hOuter) / 2;
+    const xi = (svgSize - wInner) / 2;
+    const yi = (svgSize - hInner) / 2;
+
+    return (
+      <g>
+        <rect x={x} y={y} width={wOuter} height={hOuter}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        <rect x={xi} y={yi} width={wInner} height={hInner}
+          className="fill-white dark:fill-gray-800 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        <text x={x + wOuter / 2} y={y - 5} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">B={B}</text>
+        <text x={x + wOuter + 5} y={y + hOuter / 2} textAnchor="start"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">H={H}</text>
+        <text x={x + wOuter / 2} y={y + hOuter + 15} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">t={t}</text>
+      </g>
+    );
+  };
+
+  const renderHBeam = () => {
+    const B = dimensions.flangeWidth || 200;
+    const H = dimensions.webHeight || 400;
+    const tf = dimensions.flangeThickness || 16;
+    const tw = dimensions.webThickness || 10;
+    const maxDim = Math.max(B, H);
+    const scale = (svgSize - padding * 2) / maxDim;
+
+    const width = B * scale;
+    const height = H * scale;
+    const flangeH = tf * scale;
+    const webW = tw * scale;
+    const cx = svgSize / 2;
+    const cy = svgSize / 2;
+
+    return (
+      <g>
+        {/* 上フランジ */}
+        <rect x={cx - width / 2} y={cy - height / 2} width={width} height={flangeH}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        {/* 下フランジ */}
+        <rect x={cx - width / 2} y={cy + height / 2 - flangeH} width={width} height={flangeH}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        {/* ウェブ */}
+        <rect x={cx - webW / 2} y={cy - height / 2 + flangeH} width={webW} height={height - 2 * flangeH}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400" strokeWidth="2" />
+        {/* 寸法 */}
+        <text x={cx} y={cy - height / 2 - 5} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">B={B}</text>
+        <text x={cx + width / 2 + 5} y={cy} textAnchor="start"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">H={H}</text>
+      </g>
+    );
+  };
+
+  const renderLAngle = () => {
+    const A = dimensions.legA || 100;
+    const B = dimensions.legB || 100;
+    const t = dimensions.legThickness || 10;
+    const maxDim = Math.max(A, B);
+    const scale = (svgSize - padding * 2) / maxDim;
+
+    const legALen = A * scale;
+    const legBLen = B * scale;
+    const thickness = t * scale;
+    const baseX = padding + 10;
+    const baseY = svgSize - padding - 10;
+
+    // 図心表示
+    const Cx = properties?.centroidX;
+    const Cy = properties?.centroidY;
+
+    return (
+      <g>
+        {/* L型断面 */}
+        <polygon
+          points={`
+            ${baseX},${baseY}
+            ${baseX + legALen},${baseY}
+            ${baseX + legALen},${baseY - thickness}
+            ${baseX + thickness},${baseY - thickness}
+            ${baseX + thickness},${baseY - legBLen}
+            ${baseX},${baseY - legBLen}
+          `}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400"
+          strokeWidth="2"
+        />
+        {/* 寸法 */}
+        <text x={baseX + legALen / 2} y={baseY + 15} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">A={A}</text>
+        <text x={baseX - 10} y={baseY - legBLen / 2} textAnchor="end"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">B={B}</text>
+        {/* 図心マーク */}
+        {Cx !== undefined && Cy !== undefined && (
+          <g>
+            <circle cx={baseX + Cx * scale} cy={baseY - Cy * scale} r="3"
+              className="fill-red-500" />
+            <text x={baseX + Cx * scale + 8} y={baseY - Cy * scale + 4}
+              className="fill-red-600 dark:fill-red-400 text-xs">G</text>
+          </g>
+        )}
+      </g>
+    );
+  };
+
+  const renderChannel = () => {
+    const B = dimensions.channelWidth || 75;
+    const H = dimensions.channelHeight || 150;
+    const tf = dimensions.channelFlangeThickness || 10;
+    const tw = dimensions.channelWebThickness || 6;
+    const maxDim = Math.max(B * 1.5, H);
+    const scale = (svgSize - padding * 2) / maxDim;
+
+    const width = B * scale;
+    const height = H * scale;
+    const flangeH = tf * scale;
+    const webW = tw * scale;
+    const cx = svgSize / 2;
+    const cy = svgSize / 2;
+
+    // 図心表示
+    const Cx = properties?.centroidX;
+
+    return (
+      <g>
+        {/* 溝型断面 */}
+        <polygon
+          points={`
+            ${cx - width / 2},${cy - height / 2}
+            ${cx + width / 2},${cy - height / 2}
+            ${cx + width / 2},${cy - height / 2 + flangeH}
+            ${cx - width / 2 + webW},${cy - height / 2 + flangeH}
+            ${cx - width / 2 + webW},${cy + height / 2 - flangeH}
+            ${cx + width / 2},${cy + height / 2 - flangeH}
+            ${cx + width / 2},${cy + height / 2}
+            ${cx - width / 2},${cy + height / 2}
+          `}
+          className="fill-blue-100 dark:fill-blue-900 stroke-blue-600 dark:stroke-blue-400"
+          strokeWidth="2"
+        />
+        {/* 寸法 */}
+        <text x={cx} y={cy - height / 2 - 5} textAnchor="middle"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">B={B}</text>
+        <text x={cx + width / 2 + 5} y={cy} textAnchor="start"
+          className="fill-gray-700 dark:fill-gray-300 text-xs">H={H}</text>
+        {/* 図心マーク */}
+        {Cx !== undefined && (
+          <g>
+            <circle cx={cx - width / 2 + Cx * scale} cy={cy} r="3"
+              className="fill-red-500" />
+            <text x={cx - width / 2 + Cx * scale + 8} y={cy + 4}
+              className="fill-red-600 dark:fill-red-400 text-xs">G</text>
+          </g>
+        )}
+      </g>
+    );
+  };
+
+  return (
+    <svg viewBox={viewBox} className="w-full h-full max-w-[200px] max-h-[200px]">
+      {renderShape()}
+    </svg>
+  );
+};
+
+export default SectionDiagram;

--- a/src/components/section/SectionPropertyCalculator.tsx
+++ b/src/components/section/SectionPropertyCalculator.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Circle, Square, Minus } from 'lucide-react';
+import { useSectionCalculator } from '../../hooks/useSectionCalculator';
+import type { SectionShapeType, SectionDimensions } from '../../types';
+import SectionDiagram from './SectionDiagram';
+import DimensionInputs from './DimensionInputs';
+import ResultsDisplay from './ResultsDisplay';
+import StandardSectionList from './StandardSectionList';
+
+interface ShapeOption {
+  type: SectionShapeType;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const shapeOptions: ShapeOption[] = [
+  { type: 'circle', label: '丸', icon: <Circle className="w-5 h-5" /> },
+  { type: 'pipe', label: '丸パイプ', icon: <Circle className="w-5 h-5" strokeWidth={3} /> },
+  { type: 'rectangle', label: '四角', icon: <Square className="w-5 h-5" /> },
+  { type: 'box', label: '角パイプ', icon: <Square className="w-5 h-5" strokeWidth={3} /> },
+  { type: 'h-beam', label: 'H型', icon: <span className="font-bold text-lg">H</span> },
+  { type: 'l-angle', label: 'L型', icon: <span className="font-bold text-lg">L</span> },
+  { type: 'channel', label: '溝型', icon: <Minus className="w-5 h-5 rotate-90" /> },
+];
+
+const SectionPropertyCalculator: React.FC = () => {
+  const {
+    shapeType,
+    setShapeType,
+    dimensions,
+    setDimensions,
+    updateDimension,
+    properties,
+    validationErrors,
+  } = useSectionCalculator();
+
+  const handleStandardSelect = (dims: SectionDimensions) => {
+    setDimensions(dims);
+  };
+
+  return (
+    <div className="w-full px-4 sm:px-6 xl:px-12 3xl:px-16 py-6">
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800 dark:text-gray-100 transition-colors duration-200">
+          断面性能計算
+        </h1>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">
+          各種断面の面積、断面2次モーメント、断面係数、断面2次半径を計算します
+        </p>
+      </div>
+
+      {/* 断面形状選択 */}
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-3">
+          断面形状
+        </h2>
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-7 gap-2">
+          {shapeOptions.map((option) => (
+            <button
+              key={option.type}
+              onClick={() => setShapeType(option.type)}
+              className={`flex flex-col items-center justify-center p-3 rounded-lg border-2 transition-all duration-200 ${
+                shapeType === option.type
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 text-gray-700 dark:text-gray-300'
+              }`}
+            >
+              <div className="mb-1">{option.icon}</div>
+              <span className="text-sm font-medium">{option.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* 左: 図と寸法入力 */}
+        <div className="lg:col-span-1 space-y-6">
+          {/* 断面図 */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 transition-colors duration-200">
+            <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">
+              断面形状
+            </h3>
+            <div className="flex justify-center items-center min-h-[200px]">
+              <SectionDiagram
+                shapeType={shapeType}
+                dimensions={dimensions}
+                properties={properties}
+              />
+            </div>
+          </div>
+
+          {/* 寸法入力 */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 transition-colors duration-200">
+            <DimensionInputs
+              shapeType={shapeType}
+              dimensions={dimensions}
+              onUpdate={updateDimension}
+              validationErrors={validationErrors}
+            />
+          </div>
+
+          {/* 計算結果 */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 transition-colors duration-200">
+            <ResultsDisplay properties={properties} shapeType={shapeType} />
+          </div>
+        </div>
+
+        {/* 右: 規格断面リスト */}
+        <div className="lg:col-span-2">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 transition-colors duration-200">
+            <StandardSectionList
+              shapeType={shapeType}
+              onSelect={handleStandardSelect}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SectionPropertyCalculator;

--- a/src/components/section/StandardSectionList.tsx
+++ b/src/components/section/StandardSectionList.tsx
@@ -37,6 +37,9 @@ const StandardSectionList: React.FC<StandardSectionListProps> = ({ shapeType, on
     onSelect(section.dimensions);
   };
 
+  // 回転対称断面かどうか（丸と丸パイプは回転対称）
+  const isAxisymmetric = shapeType === 'circle' || shapeType === 'pipe';
+
   if (sections.length === 0) {
     return (
       <div className="text-center py-8 text-gray-500 dark:text-gray-400">
@@ -82,14 +85,29 @@ const StandardSectionList: React.FC<StandardSectionListProps> = ({ shapeType, on
                 A (mm²)
               </th>
               <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
-                Ix (mm⁴)
+                {isAxisymmetric ? 'I (mm⁴)' : 'Ix (mm⁴)'}
               </th>
+              {!isAxisymmetric && (
+                <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                  Iy (mm⁴)
+                </th>
+              )}
               <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
-                Zx (mm³)
+                {isAxisymmetric ? 'Z (mm³)' : 'Zx (mm³)'}
               </th>
+              {!isAxisymmetric && (
+                <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                  Zy (mm³)
+                </th>
+              )}
               <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
-                ix (mm)
+                {isAxisymmetric ? 'i (mm)' : 'ix (mm)'}
               </th>
+              {!isAxisymmetric && (
+                <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                  iy (mm)
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -112,12 +130,27 @@ const StandardSectionList: React.FC<StandardSectionListProps> = ({ shapeType, on
                 <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
                   {formatNumber(section.properties.momentOfInertiaX)}
                 </td>
+                {!isAxisymmetric && (
+                  <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                    {formatNumber(section.properties.momentOfInertiaY)}
+                  </td>
+                )}
                 <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
                   {formatNumber(section.properties.sectionModulusX)}
                 </td>
+                {!isAxisymmetric && (
+                  <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                    {formatNumber(section.properties.sectionModulusY)}
+                  </td>
+                )}
                 <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
                   {formatNumber(section.properties.radiusOfGyrationX)}
                 </td>
+                {!isAxisymmetric && (
+                  <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                    {formatNumber(section.properties.radiusOfGyrationY)}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/src/components/section/StandardSectionList.tsx
+++ b/src/components/section/StandardSectionList.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import type { SectionShapeType, StandardSection, SectionDimensions } from '../../types';
+import { getStandardSections } from './standardSections';
+
+interface StandardSectionListProps {
+  shapeType: SectionShapeType;
+  onSelect: (dimensions: SectionDimensions) => void;
+}
+
+// 数値フォーマット
+function formatNumber(value: number): string {
+  if (value === 0) return '0';
+  if (Math.abs(value) >= 1e6) {
+    return value.toExponential(2);
+  }
+  if (Math.abs(value) >= 1000) {
+    return Math.round(value).toLocaleString('ja-JP');
+  }
+  return value.toFixed(1);
+}
+
+const StandardSectionList: React.FC<StandardSectionListProps> = ({ shapeType, onSelect }) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const sections = useMemo(() => getStandardSections(shapeType), [shapeType]);
+
+  const filteredSections = useMemo(() => {
+    if (!searchQuery.trim()) return sections;
+    const query = searchQuery.toLowerCase();
+    return sections.filter(s => s.name.toLowerCase().includes(query));
+  }, [sections, searchQuery]);
+
+  const handleSelect = (section: StandardSection) => {
+    setSelectedId(section.id);
+    onSelect(section.dimensions);
+  };
+
+  if (sections.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+        この断面形状には規格断面データがありません。
+        <br />
+        寸法を直接入力してください。
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
+          規格断面リスト
+        </h3>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {filteredSections.length} 件
+        </span>
+      </div>
+
+      {/* 検索ボックス */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="規格名で検索..."
+          className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+        />
+      </div>
+
+      {/* テーブル */}
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300">
+                規格名
+              </th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                A (mm²)
+              </th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                Ix (mm⁴)
+              </th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                Zx (mm³)
+              </th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700 dark:text-gray-300">
+                ix (mm)
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {filteredSections.map((section) => (
+              <tr
+                key={section.id}
+                onClick={() => handleSelect(section)}
+                className={`cursor-pointer transition-colors duration-150 ${
+                  selectedId === section.id
+                    ? 'bg-blue-50 dark:bg-blue-900/30'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                }`}
+              >
+                <td className="px-3 py-2 font-mono text-gray-900 dark:text-gray-100">
+                  {section.name}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                  {formatNumber(section.properties.area)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                  {formatNumber(section.properties.momentOfInertiaX)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                  {formatNumber(section.properties.sectionModulusX)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                  {formatNumber(section.properties.radiusOfGyrationX)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+        行をクリックすると寸法が入力欄に反映されます
+      </p>
+    </div>
+  );
+};
+
+export default StandardSectionList;

--- a/src/components/section/standardSections.ts
+++ b/src/components/section/standardSections.ts
@@ -1,0 +1,212 @@
+import type { StandardSection, SectionShapeType } from '../../types';
+import { calculateSectionProperties } from '../../hooks/useSectionCalculator';
+
+// ヘルパー関数：寸法から規格断面を生成
+function createStandardSection(
+  id: string,
+  name: string,
+  type: SectionShapeType,
+  dimensions: StandardSection['dimensions']
+): StandardSection | null {
+  const properties = calculateSectionProperties(type, dimensions);
+  if (!properties) return null;
+  return { id, name, type, dimensions, properties };
+}
+
+// 丸鋼（円形断面）
+export const circleStandards: StandardSection[] = [
+  { diameter: 10 },
+  { diameter: 13 },
+  { diameter: 16 },
+  { diameter: 19 },
+  { diameter: 22 },
+  { diameter: 25 },
+  { diameter: 28 },
+  { diameter: 32 },
+  { diameter: 38 },
+  { diameter: 44 },
+  { diameter: 50 },
+  { diameter: 60 },
+  { diameter: 70 },
+  { diameter: 80 },
+  { diameter: 90 },
+  { diameter: 100 },
+].map((dims, i) => createStandardSection(
+  `circle-${i}`,
+  `φ${dims.diameter}`,
+  'circle',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// 丸パイプ（SGP鋼管相当）
+export const pipeStandards: StandardSection[] = [
+  { outerDiameter: 21.7, innerDiameter: 15.9 },   // 15A
+  { outerDiameter: 27.2, innerDiameter: 21.4 },   // 20A
+  { outerDiameter: 34.0, innerDiameter: 27.6 },   // 25A
+  { outerDiameter: 42.7, innerDiameter: 35.5 },   // 32A
+  { outerDiameter: 48.6, innerDiameter: 41.2 },   // 40A
+  { outerDiameter: 60.5, innerDiameter: 52.7 },   // 50A
+  { outerDiameter: 76.3, innerDiameter: 67.9 },   // 65A
+  { outerDiameter: 89.1, innerDiameter: 80.1 },   // 80A
+  { outerDiameter: 101.6, innerDiameter: 92.0 },  // 90A
+  { outerDiameter: 114.3, innerDiameter: 105.3 }, // 100A
+  { outerDiameter: 139.8, innerDiameter: 130.0 }, // 125A
+  { outerDiameter: 165.2, innerDiameter: 154.8 }, // 150A
+  { outerDiameter: 216.3, innerDiameter: 204.7 }, // 200A
+].map((dims, i) => createStandardSection(
+  `pipe-${i}`,
+  `φ${dims.outerDiameter}×${((dims.outerDiameter - dims.innerDiameter) / 2).toFixed(1)}t`,
+  'pipe',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// 角パイプ（一般構造用角形鋼管 STKR相当）
+export const boxStandards: StandardSection[] = [
+  { outerWidth: 50, outerHeight: 50, thickness: 2.3 },
+  { outerWidth: 50, outerHeight: 50, thickness: 3.2 },
+  { outerWidth: 60, outerHeight: 60, thickness: 2.3 },
+  { outerWidth: 60, outerHeight: 60, thickness: 3.2 },
+  { outerWidth: 75, outerHeight: 75, thickness: 2.3 },
+  { outerWidth: 75, outerHeight: 75, thickness: 3.2 },
+  { outerWidth: 75, outerHeight: 75, thickness: 4.5 },
+  { outerWidth: 100, outerHeight: 100, thickness: 3.2 },
+  { outerWidth: 100, outerHeight: 100, thickness: 4.5 },
+  { outerWidth: 100, outerHeight: 100, thickness: 6.0 },
+  { outerWidth: 125, outerHeight: 125, thickness: 4.5 },
+  { outerWidth: 125, outerHeight: 125, thickness: 6.0 },
+  { outerWidth: 150, outerHeight: 150, thickness: 4.5 },
+  { outerWidth: 150, outerHeight: 150, thickness: 6.0 },
+  { outerWidth: 150, outerHeight: 150, thickness: 9.0 },
+  { outerWidth: 200, outerHeight: 200, thickness: 6.0 },
+  { outerWidth: 200, outerHeight: 200, thickness: 9.0 },
+  { outerWidth: 250, outerHeight: 250, thickness: 6.0 },
+  { outerWidth: 250, outerHeight: 250, thickness: 9.0 },
+  // 矩形パイプ
+  { outerWidth: 100, outerHeight: 50, thickness: 3.2 },
+  { outerWidth: 100, outerHeight: 50, thickness: 4.5 },
+  { outerWidth: 150, outerHeight: 75, thickness: 4.5 },
+  { outerWidth: 150, outerHeight: 100, thickness: 4.5 },
+  { outerWidth: 200, outerHeight: 100, thickness: 4.5 },
+  { outerWidth: 200, outerHeight: 100, thickness: 6.0 },
+].map((dims, i) => createStandardSection(
+  `box-${i}`,
+  `□${dims.outerWidth}×${dims.outerHeight}×${dims.thickness}`,
+  'box',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// H形鋼（JIS G 3192相当）
+export const hBeamStandards: StandardSection[] = [
+  // 細幅H形鋼
+  { flangeWidth: 100, webHeight: 100, flangeThickness: 6, webThickness: 6 },
+  { flangeWidth: 100, webHeight: 200, flangeThickness: 8, webThickness: 5.5 },
+  { flangeWidth: 125, webHeight: 250, flangeThickness: 9, webThickness: 6 },
+  { flangeWidth: 150, webHeight: 300, flangeThickness: 9, webThickness: 6.5 },
+  { flangeWidth: 150, webHeight: 350, flangeThickness: 12, webThickness: 7 },
+  { flangeWidth: 175, webHeight: 400, flangeThickness: 11, webThickness: 8 },
+  { flangeWidth: 175, webHeight: 450, flangeThickness: 11, webThickness: 9 },
+  { flangeWidth: 200, webHeight: 500, flangeThickness: 14, webThickness: 10 },
+  { flangeWidth: 200, webHeight: 600, flangeThickness: 15, webThickness: 11 },
+  // 中幅H形鋼
+  { flangeWidth: 150, webHeight: 150, flangeThickness: 7, webThickness: 7 },
+  { flangeWidth: 175, webHeight: 175, flangeThickness: 7.5, webThickness: 7.5 },
+  { flangeWidth: 200, webHeight: 200, flangeThickness: 8, webThickness: 8 },
+  { flangeWidth: 200, webHeight: 200, flangeThickness: 12, webThickness: 12 },
+  { flangeWidth: 250, webHeight: 250, flangeThickness: 9, webThickness: 9 },
+  { flangeWidth: 250, webHeight: 250, flangeThickness: 14, webThickness: 14 },
+  { flangeWidth: 300, webHeight: 300, flangeThickness: 10, webThickness: 10 },
+  { flangeWidth: 300, webHeight: 300, flangeThickness: 15, webThickness: 15 },
+  { flangeWidth: 350, webHeight: 350, flangeThickness: 12, webThickness: 12 },
+  { flangeWidth: 400, webHeight: 400, flangeThickness: 13, webThickness: 13 },
+  // 広幅H形鋼
+  { flangeWidth: 200, webHeight: 100, flangeThickness: 10, webThickness: 6 },
+  { flangeWidth: 300, webHeight: 150, flangeThickness: 12, webThickness: 6.5 },
+  { flangeWidth: 300, webHeight: 200, flangeThickness: 16, webThickness: 10 },
+  { flangeWidth: 300, webHeight: 300, flangeThickness: 20, webThickness: 12 },
+  { flangeWidth: 400, webHeight: 200, flangeThickness: 16, webThickness: 10 },
+].map((dims, i) => createStandardSection(
+  `h-beam-${i}`,
+  `H${dims.webHeight}×${dims.flangeWidth}×${dims.webThickness}×${dims.flangeThickness}`,
+  'h-beam',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// 等辺山形鋼（JIS G 3192相当）
+export const lAngleStandards: StandardSection[] = [
+  // 等辺
+  { legA: 25, legB: 25, legThickness: 3 },
+  { legA: 30, legB: 30, legThickness: 3 },
+  { legA: 40, legB: 40, legThickness: 3 },
+  { legA: 40, legB: 40, legThickness: 5 },
+  { legA: 50, legB: 50, legThickness: 4 },
+  { legA: 50, legB: 50, legThickness: 6 },
+  { legA: 60, legB: 60, legThickness: 5 },
+  { legA: 60, legB: 60, legThickness: 6 },
+  { legA: 65, legB: 65, legThickness: 6 },
+  { legA: 70, legB: 70, legThickness: 6 },
+  { legA: 75, legB: 75, legThickness: 6 },
+  { legA: 75, legB: 75, legThickness: 9 },
+  { legA: 80, legB: 80, legThickness: 6 },
+  { legA: 90, legB: 90, legThickness: 7 },
+  { legA: 90, legB: 90, legThickness: 10 },
+  { legA: 100, legB: 100, legThickness: 7 },
+  { legA: 100, legB: 100, legThickness: 10 },
+  { legA: 100, legB: 100, legThickness: 13 },
+  { legA: 120, legB: 120, legThickness: 8 },
+  { legA: 130, legB: 130, legThickness: 9 },
+  { legA: 130, legB: 130, legThickness: 12 },
+  { legA: 150, legB: 150, legThickness: 12 },
+  { legA: 150, legB: 150, legThickness: 15 },
+  // 不等辺
+  { legA: 75, legB: 50, legThickness: 6 },
+  { legA: 90, legB: 75, legThickness: 6 },
+  { legA: 100, legB: 75, legThickness: 7 },
+  { legA: 125, legB: 75, legThickness: 7 },
+  { legA: 150, legB: 90, legThickness: 9 },
+  { legA: 150, legB: 100, legThickness: 9 },
+].map((dims, i) => createStandardSection(
+  `l-angle-${i}`,
+  `L${dims.legA}×${dims.legB}×${dims.legThickness}`,
+  'l-angle',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// 溝形鋼（JIS G 3192相当）
+export const channelStandards: StandardSection[] = [
+  { channelWidth: 40, channelHeight: 75, channelFlangeThickness: 5, channelWebThickness: 5 },
+  { channelWidth: 45, channelHeight: 100, channelFlangeThickness: 6, channelWebThickness: 5 },
+  { channelWidth: 50, channelHeight: 125, channelFlangeThickness: 6.5, channelWebThickness: 5.5 },
+  { channelWidth: 53, channelHeight: 150, channelFlangeThickness: 7.5, channelWebThickness: 6.5 },
+  { channelWidth: 58, channelHeight: 180, channelFlangeThickness: 8, channelWebThickness: 7 },
+  { channelWidth: 65, channelHeight: 200, channelFlangeThickness: 9, channelWebThickness: 7.5 },
+  { channelWidth: 75, channelHeight: 250, channelFlangeThickness: 11, channelWebThickness: 9 },
+  { channelWidth: 80, channelHeight: 300, channelFlangeThickness: 12, channelWebThickness: 9 },
+  { channelWidth: 85, channelHeight: 380, channelFlangeThickness: 13.5, channelWebThickness: 10.5 },
+].map((dims, i) => createStandardSection(
+  `channel-${i}`,
+  `[${dims.channelHeight}×${dims.channelWidth}×${dims.channelWebThickness}×${dims.channelFlangeThickness}`,
+  'channel',
+  dims
+)).filter((s): s is StandardSection => s !== null);
+
+// 全規格断面を形状タイプごとに取得
+export function getStandardSections(type: SectionShapeType): StandardSection[] {
+  switch (type) {
+    case 'circle':
+      return circleStandards;
+    case 'pipe':
+      return pipeStandards;
+    case 'rectangle':
+      return []; // 矩形は規格断面なし
+    case 'box':
+      return boxStandards;
+    case 'h-beam':
+      return hBeamStandards;
+    case 'l-angle':
+      return lAngleStandards;
+    case 'channel':
+      return channelStandards;
+    default:
+      return [];
+  }
+}

--- a/src/components/section/standardSections.ts
+++ b/src/components/section/standardSections.ts
@@ -95,35 +95,70 @@ export const boxStandards: StandardSection[] = [
   dims
 )).filter((s): s is StandardSection => s !== null);
 
-// H形鋼（JIS G 3192相当）
+// H形鋼（JIS G 3192 熱間圧延H形鋼）
+// 表記: H × B × t1 × t2 (高さ × フランジ幅 × ウェブ厚 × フランジ厚)
 export const hBeamStandards: StandardSection[] = [
-  // 細幅H形鋼
-  { flangeWidth: 100, webHeight: 100, flangeThickness: 6, webThickness: 6 },
-  { flangeWidth: 100, webHeight: 200, flangeThickness: 8, webThickness: 5.5 },
-  { flangeWidth: 125, webHeight: 250, flangeThickness: 9, webThickness: 6 },
-  { flangeWidth: 150, webHeight: 300, flangeThickness: 9, webThickness: 6.5 },
-  { flangeWidth: 150, webHeight: 350, flangeThickness: 12, webThickness: 7 },
-  { flangeWidth: 175, webHeight: 400, flangeThickness: 11, webThickness: 8 },
-  { flangeWidth: 175, webHeight: 450, flangeThickness: 11, webThickness: 9 },
-  { flangeWidth: 200, webHeight: 500, flangeThickness: 14, webThickness: 10 },
-  { flangeWidth: 200, webHeight: 600, flangeThickness: 15, webThickness: 11 },
-  // 中幅H形鋼
-  { flangeWidth: 150, webHeight: 150, flangeThickness: 7, webThickness: 7 },
-  { flangeWidth: 175, webHeight: 175, flangeThickness: 7.5, webThickness: 7.5 },
-  { flangeWidth: 200, webHeight: 200, flangeThickness: 8, webThickness: 8 },
-  { flangeWidth: 200, webHeight: 200, flangeThickness: 12, webThickness: 12 },
-  { flangeWidth: 250, webHeight: 250, flangeThickness: 9, webThickness: 9 },
-  { flangeWidth: 250, webHeight: 250, flangeThickness: 14, webThickness: 14 },
-  { flangeWidth: 300, webHeight: 300, flangeThickness: 10, webThickness: 10 },
-  { flangeWidth: 300, webHeight: 300, flangeThickness: 15, webThickness: 15 },
-  { flangeWidth: 350, webHeight: 350, flangeThickness: 12, webThickness: 12 },
-  { flangeWidth: 400, webHeight: 400, flangeThickness: 13, webThickness: 13 },
-  // 広幅H形鋼
-  { flangeWidth: 200, webHeight: 100, flangeThickness: 10, webThickness: 6 },
-  { flangeWidth: 300, webHeight: 150, flangeThickness: 12, webThickness: 6.5 },
-  { flangeWidth: 300, webHeight: 200, flangeThickness: 16, webThickness: 10 },
-  { flangeWidth: 300, webHeight: 300, flangeThickness: 20, webThickness: 12 },
-  { flangeWidth: 400, webHeight: 200, flangeThickness: 16, webThickness: 10 },
+  // 細幅系列 (H x B where B is narrow)
+  { webHeight: 100, flangeWidth: 50, webThickness: 5, flangeThickness: 7 },
+  { webHeight: 100, flangeWidth: 100, webThickness: 6, flangeThickness: 8 },
+  { webHeight: 125, flangeWidth: 60, webThickness: 6, flangeThickness: 8 },
+  { webHeight: 125, flangeWidth: 125, webThickness: 6.5, flangeThickness: 9 },
+  { webHeight: 150, flangeWidth: 75, webThickness: 5, flangeThickness: 7 },
+  { webHeight: 150, flangeWidth: 100, webThickness: 6, flangeThickness: 9 },
+  { webHeight: 150, flangeWidth: 150, webThickness: 7, flangeThickness: 10 },
+  { webHeight: 175, flangeWidth: 90, webThickness: 5, flangeThickness: 8 },
+  { webHeight: 175, flangeWidth: 175, webThickness: 7.5, flangeThickness: 11 },
+  { webHeight: 198, flangeWidth: 99, webThickness: 4.5, flangeThickness: 7 },
+  { webHeight: 200, flangeWidth: 100, webThickness: 5.5, flangeThickness: 8 },
+  { webHeight: 194, flangeWidth: 150, webThickness: 6, flangeThickness: 9 },
+  { webHeight: 200, flangeWidth: 200, webThickness: 8, flangeThickness: 12 },
+  { webHeight: 248, flangeWidth: 124, webThickness: 5, flangeThickness: 8 },
+  { webHeight: 250, flangeWidth: 125, webThickness: 6, flangeThickness: 9 },
+  { webHeight: 244, flangeWidth: 175, webThickness: 7, flangeThickness: 11 },
+  { webHeight: 250, flangeWidth: 250, webThickness: 9, flangeThickness: 14 },
+  { webHeight: 298, flangeWidth: 149, webThickness: 5.5, flangeThickness: 8 },
+  { webHeight: 300, flangeWidth: 150, webThickness: 6.5, flangeThickness: 9 },
+  { webHeight: 294, flangeWidth: 200, webThickness: 8, flangeThickness: 12 },
+  { webHeight: 300, flangeWidth: 300, webThickness: 10, flangeThickness: 15 },
+  { webHeight: 346, flangeWidth: 174, webThickness: 6, flangeThickness: 9 },
+  { webHeight: 350, flangeWidth: 175, webThickness: 7, flangeThickness: 11 },
+  { webHeight: 340, flangeWidth: 250, webThickness: 9, flangeThickness: 14 },
+  { webHeight: 350, flangeWidth: 350, webThickness: 12, flangeThickness: 19 },
+  // 400シリーズ
+  { webHeight: 396, flangeWidth: 199, webThickness: 7, flangeThickness: 11 },
+  { webHeight: 400, flangeWidth: 200, webThickness: 8, flangeThickness: 13 },
+  { webHeight: 390, flangeWidth: 300, webThickness: 10, flangeThickness: 16 },
+  { webHeight: 400, flangeWidth: 400, webThickness: 13, flangeThickness: 21 },
+  { webHeight: 414, flangeWidth: 405, webThickness: 18, flangeThickness: 28 },
+  { webHeight: 428, flangeWidth: 407, webThickness: 20, flangeThickness: 35 },
+  { webHeight: 458, flangeWidth: 417, webThickness: 30, flangeThickness: 50 },
+  { webHeight: 498, flangeWidth: 432, webThickness: 45, flangeThickness: 70 },
+  // 450シリーズ
+  { webHeight: 446, flangeWidth: 199, webThickness: 8, flangeThickness: 12 },
+  { webHeight: 450, flangeWidth: 200, webThickness: 9, flangeThickness: 14 },
+  { webHeight: 440, flangeWidth: 300, webThickness: 11, flangeThickness: 18 },
+  // 500シリーズ
+  { webHeight: 496, flangeWidth: 199, webThickness: 9, flangeThickness: 14 },
+  { webHeight: 500, flangeWidth: 200, webThickness: 10, flangeThickness: 16 },
+  { webHeight: 482, flangeWidth: 300, webThickness: 11, flangeThickness: 15 },
+  { webHeight: 488, flangeWidth: 300, webThickness: 11, flangeThickness: 18 },
+  // 600シリーズ
+  { webHeight: 596, flangeWidth: 199, webThickness: 10, flangeThickness: 15 },
+  { webHeight: 600, flangeWidth: 200, webThickness: 11, flangeThickness: 17 },
+  { webHeight: 582, flangeWidth: 300, webThickness: 12, flangeThickness: 17 },
+  { webHeight: 588, flangeWidth: 300, webThickness: 12, flangeThickness: 20 },
+  // 700シリーズ
+  { webHeight: 594, flangeWidth: 302, webThickness: 14, flangeThickness: 23 },
+  { webHeight: 692, flangeWidth: 300, webThickness: 13, flangeThickness: 20 },
+  { webHeight: 700, flangeWidth: 300, webThickness: 13, flangeThickness: 24 },
+  // 800シリーズ
+  { webHeight: 792, flangeWidth: 300, webThickness: 14, flangeThickness: 22 },
+  { webHeight: 800, flangeWidth: 300, webThickness: 14, flangeThickness: 26 },
+  // 900シリーズ
+  { webHeight: 890, flangeWidth: 299, webThickness: 15, flangeThickness: 23 },
+  { webHeight: 900, flangeWidth: 300, webThickness: 16, flangeThickness: 28 },
+  { webHeight: 912, flangeWidth: 302, webThickness: 18, flangeThickness: 34 },
+  { webHeight: 918, flangeWidth: 303, webThickness: 19, flangeThickness: 37 },
 ].map((dims, i) => createStandardSection(
   `h-beam-${i}`,
   `H${dims.webHeight}×${dims.flangeWidth}×${dims.webThickness}×${dims.flangeThickness}`,

--- a/src/hooks/useSectionCalculator.ts
+++ b/src/hooks/useSectionCalculator.ts
@@ -1,0 +1,462 @@
+import { useState, useMemo, useCallback } from 'react';
+import type { SectionShapeType, SectionDimensions, SectionProperties } from '../types';
+
+interface UseSectionCalculatorReturn {
+  shapeType: SectionShapeType;
+  setShapeType: (type: SectionShapeType) => void;
+  dimensions: SectionDimensions;
+  setDimensions: (dims: SectionDimensions) => void;
+  updateDimension: (key: keyof SectionDimensions, value: number) => void;
+  properties: SectionProperties | null;
+  isValid: boolean;
+  validationErrors: string[];
+}
+
+// 断面性能計算関数
+export function calculateSectionProperties(
+  shapeType: SectionShapeType,
+  dimensions: SectionDimensions
+): SectionProperties | null {
+  switch (shapeType) {
+    case 'circle':
+      return calculateCircle(dimensions);
+    case 'pipe':
+      return calculatePipe(dimensions);
+    case 'rectangle':
+      return calculateRectangle(dimensions);
+    case 'box':
+      return calculateBox(dimensions);
+    case 'h-beam':
+      return calculateHBeam(dimensions);
+    case 'l-angle':
+      return calculateLAngle(dimensions);
+    case 'channel':
+      return calculateChannel(dimensions);
+    default:
+      return null;
+  }
+}
+
+// 円形断面
+function calculateCircle(dims: SectionDimensions): SectionProperties | null {
+  const D = dims.diameter;
+  if (!D || D <= 0) return null;
+
+  const r = D / 2;
+  const area = Math.PI * r * r;
+  const I = (Math.PI * Math.pow(D, 4)) / 64;
+  const Z = (Math.PI * Math.pow(D, 3)) / 32;
+  const i = Math.sqrt(I / area);
+
+  return {
+    area,
+    momentOfInertiaX: I,
+    momentOfInertiaY: I,
+    radiusOfGyrationX: i,
+    radiusOfGyrationY: i,
+    sectionModulusX: Z,
+    sectionModulusY: Z,
+  };
+}
+
+// 丸パイプ（中空円形）
+function calculatePipe(dims: SectionDimensions): SectionProperties | null {
+  const D = dims.outerDiameter;
+  const d = dims.innerDiameter;
+  if (!D || !d || D <= 0 || d <= 0 || d >= D) return null;
+
+  const area = (Math.PI / 4) * (D * D - d * d);
+  const I = (Math.PI / 64) * (Math.pow(D, 4) - Math.pow(d, 4));
+  const Z = I / (D / 2);
+  const i = Math.sqrt(I / area);
+
+  return {
+    area,
+    momentOfInertiaX: I,
+    momentOfInertiaY: I,
+    radiusOfGyrationX: i,
+    radiusOfGyrationY: i,
+    sectionModulusX: Z,
+    sectionModulusY: Z,
+  };
+}
+
+// 矩形断面
+function calculateRectangle(dims: SectionDimensions): SectionProperties | null {
+  const B = dims.width;
+  const H = dims.height;
+  if (!B || !H || B <= 0 || H <= 0) return null;
+
+  const area = B * H;
+  const Ix = (B * Math.pow(H, 3)) / 12;
+  const Iy = (H * Math.pow(B, 3)) / 12;
+  const Zx = (B * Math.pow(H, 2)) / 6;
+  const Zy = (H * Math.pow(B, 2)) / 6;
+  const ix = Math.sqrt(Ix / area);
+  const iy = Math.sqrt(Iy / area);
+
+  return {
+    area,
+    momentOfInertiaX: Ix,
+    momentOfInertiaY: Iy,
+    radiusOfGyrationX: ix,
+    radiusOfGyrationY: iy,
+    sectionModulusX: Zx,
+    sectionModulusY: Zy,
+  };
+}
+
+// 角パイプ（中空矩形）
+function calculateBox(dims: SectionDimensions): SectionProperties | null {
+  const B = dims.outerWidth;
+  const H = dims.outerHeight;
+  const t = dims.thickness;
+
+  if (!B || !H || !t || B <= 0 || H <= 0 || t <= 0) return null;
+  if (t * 2 >= B || t * 2 >= H) return null;
+
+  const b = B - 2 * t;
+  const h = H - 2 * t;
+
+  const area = B * H - b * h;
+  const Ix = (B * Math.pow(H, 3) - b * Math.pow(h, 3)) / 12;
+  const Iy = (H * Math.pow(B, 3) - h * Math.pow(b, 3)) / 12;
+  const Zx = Ix / (H / 2);
+  const Zy = Iy / (B / 2);
+  const ix = Math.sqrt(Ix / area);
+  const iy = Math.sqrt(Iy / area);
+
+  return {
+    area,
+    momentOfInertiaX: Ix,
+    momentOfInertiaY: Iy,
+    radiusOfGyrationX: ix,
+    radiusOfGyrationY: iy,
+    sectionModulusX: Zx,
+    sectionModulusY: Zy,
+  };
+}
+
+// H型断面
+function calculateHBeam(dims: SectionDimensions): SectionProperties | null {
+  const B = dims.flangeWidth;
+  const H = dims.webHeight;
+  const tf = dims.flangeThickness;
+  const tw = dims.webThickness;
+
+  if (!B || !H || !tf || !tw) return null;
+  if (B <= 0 || H <= 0 || tf <= 0 || tw <= 0) return null;
+  if (2 * tf >= H || tw >= B) return null;
+
+  // 面積 = 2 * フランジ + ウェブ
+  const webH = H - 2 * tf;
+  const area = 2 * B * tf + webH * tw;
+
+  // 強軸（X軸）周り
+  const Ix = (B * Math.pow(H, 3) - (B - tw) * Math.pow(webH, 3)) / 12;
+  const Zx = Ix / (H / 2);
+  const ix = Math.sqrt(Ix / area);
+
+  // 弱軸（Y軸）周り
+  const Iy = (2 * tf * Math.pow(B, 3) + webH * Math.pow(tw, 3)) / 12;
+  const Zy = Iy / (B / 2);
+  const iy = Math.sqrt(Iy / area);
+
+  return {
+    area,
+    momentOfInertiaX: Ix,
+    momentOfInertiaY: Iy,
+    radiusOfGyrationX: ix,
+    radiusOfGyrationY: iy,
+    sectionModulusX: Zx,
+    sectionModulusY: Zy,
+  };
+}
+
+// L型断面（等辺・不等辺山形鋼）
+function calculateLAngle(dims: SectionDimensions): SectionProperties | null {
+  const A = dims.legA;
+  const B = dims.legB;
+  const t = dims.legThickness;
+
+  if (!A || !B || !t) return null;
+  if (A <= 0 || B <= 0 || t <= 0) return null;
+  if (t >= A || t >= B) return null;
+
+  // 面積
+  const area = t * (A + B - t);
+
+  // 図心位置（角からの距離）
+  // 辺Aの方向をX軸、辺Bの方向をY軸とする
+  const Cx = (A * t * (A / 2) + (B - t) * t * (t / 2)) / area;
+  const Cy = (B * t * (B / 2) + (A - t) * t * (t / 2)) / area;
+
+  // 断面2次モーメント（図心周り）
+  // 辺A（水平）部分
+  const IxA = (A * Math.pow(t, 3)) / 12 + A * t * Math.pow(Cy - t / 2, 2);
+  // 辺B（垂直）部分（重複部分を除く）
+  const IxB = (t * Math.pow(B - t, 3)) / 12 + t * (B - t) * Math.pow((B + t) / 2 - Cy, 2);
+  const Ix = IxA + IxB;
+
+  const IyA = (t * Math.pow(A, 3)) / 12 + A * t * Math.pow(A / 2 - Cx, 2);
+  const IyB = ((B - t) * Math.pow(t, 3)) / 12 + (B - t) * t * Math.pow(Cx - t / 2, 2);
+  const Iy = IyA + IyB;
+
+  // 断面係数（最外縁までの距離で計算）
+  const exTop = B - Cy;
+  const exBottom = Cy;
+  const eyRight = A - Cx;
+  const eyLeft = Cx;
+
+  const Zx = Ix / Math.max(exTop, exBottom);
+  const Zy = Iy / Math.max(eyRight, eyLeft);
+
+  const ix = Math.sqrt(Ix / area);
+  const iy = Math.sqrt(Iy / area);
+
+  return {
+    area,
+    momentOfInertiaX: Ix,
+    momentOfInertiaY: Iy,
+    radiusOfGyrationX: ix,
+    radiusOfGyrationY: iy,
+    sectionModulusX: Zx,
+    sectionModulusY: Zy,
+    centroidX: Cx,
+    centroidY: Cy,
+  };
+}
+
+// 溝型断面（チャンネル）
+function calculateChannel(dims: SectionDimensions): SectionProperties | null {
+  const B = dims.channelWidth;
+  const H = dims.channelHeight;
+  const tf = dims.channelFlangeThickness;
+  const tw = dims.channelWebThickness;
+
+  if (!B || !H || !tf || !tw) return null;
+  if (B <= 0 || H <= 0 || tf <= 0 || tw <= 0) return null;
+  if (2 * tf >= H || tw >= B) return null;
+
+  // 面積
+  const area = 2 * B * tf + (H - 2 * tf) * tw;
+
+  // 図心位置（ウェブから）
+  const webH = H - 2 * tf;
+  // 上下フランジ + ウェブの面積モーメント
+  const Cx = (2 * B * tf * (B / 2) + webH * tw * (tw / 2)) / area;
+
+  // X軸（強軸）周りの断面2次モーメント
+  const Ix = (tw * Math.pow(H, 3) + 2 * (B - tw) * Math.pow(tf, 3)) / 12
+           + 2 * (B - tw) * tf * Math.pow((H - tf) / 2, 2);
+
+  // Y軸（弱軸）周りの断面2次モーメント（図心周り）
+  const IyFlanges = 2 * ((tf * Math.pow(B, 3)) / 12 + B * tf * Math.pow(B / 2 - Cx, 2));
+  const IyWeb = (webH * Math.pow(tw, 3)) / 12 + webH * tw * Math.pow(Cx - tw / 2, 2);
+  const Iy = IyFlanges + IyWeb;
+
+  // 断面係数
+  const Zx = Ix / (H / 2);
+  const ZyInner = Iy / Cx;
+  const ZyOuter = Iy / (B - Cx);
+  const Zy = Math.min(ZyInner, ZyOuter);
+
+  const ix = Math.sqrt(Ix / area);
+  const iy = Math.sqrt(Iy / area);
+
+  return {
+    area,
+    momentOfInertiaX: Ix,
+    momentOfInertiaY: Iy,
+    radiusOfGyrationX: ix,
+    radiusOfGyrationY: iy,
+    sectionModulusX: Zx,
+    sectionModulusY: Zy,
+    centroidX: Cx,
+    centroidY: H / 2,
+  };
+}
+
+// バリデーション
+function validateDimensions(
+  shapeType: SectionShapeType,
+  dimensions: SectionDimensions
+): string[] {
+  const errors: string[] = [];
+
+  switch (shapeType) {
+    case 'circle':
+      if (!dimensions.diameter || dimensions.diameter <= 0) {
+        errors.push('直径は正の値を入力してください');
+      }
+      break;
+    case 'pipe':
+      if (!dimensions.outerDiameter || dimensions.outerDiameter <= 0) {
+        errors.push('外径は正の値を入力してください');
+      }
+      if (!dimensions.innerDiameter || dimensions.innerDiameter <= 0) {
+        errors.push('内径は正の値を入力してください');
+      }
+      if (dimensions.outerDiameter && dimensions.innerDiameter &&
+          dimensions.innerDiameter >= dimensions.outerDiameter) {
+        errors.push('内径は外径より小さくしてください');
+      }
+      break;
+    case 'rectangle':
+      if (!dimensions.width || dimensions.width <= 0) {
+        errors.push('幅は正の値を入力してください');
+      }
+      if (!dimensions.height || dimensions.height <= 0) {
+        errors.push('高さは正の値を入力してください');
+      }
+      break;
+    case 'box':
+      if (!dimensions.outerWidth || dimensions.outerWidth <= 0) {
+        errors.push('外幅は正の値を入力してください');
+      }
+      if (!dimensions.outerHeight || dimensions.outerHeight <= 0) {
+        errors.push('外高さは正の値を入力してください');
+      }
+      if (!dimensions.thickness || dimensions.thickness <= 0) {
+        errors.push('板厚は正の値を入力してください');
+      }
+      if (dimensions.thickness && dimensions.outerWidth &&
+          dimensions.thickness * 2 >= dimensions.outerWidth) {
+        errors.push('板厚が大きすぎます');
+      }
+      if (dimensions.thickness && dimensions.outerHeight &&
+          dimensions.thickness * 2 >= dimensions.outerHeight) {
+        errors.push('板厚が大きすぎます');
+      }
+      break;
+    case 'h-beam':
+      if (!dimensions.flangeWidth || dimensions.flangeWidth <= 0) {
+        errors.push('フランジ幅は正の値を入力してください');
+      }
+      if (!dimensions.webHeight || dimensions.webHeight <= 0) {
+        errors.push('ウェブ高さは正の値を入力してください');
+      }
+      if (!dimensions.flangeThickness || dimensions.flangeThickness <= 0) {
+        errors.push('フランジ厚さは正の値を入力してください');
+      }
+      if (!dimensions.webThickness || dimensions.webThickness <= 0) {
+        errors.push('ウェブ厚さは正の値を入力してください');
+      }
+      if (dimensions.flangeThickness && dimensions.webHeight &&
+          dimensions.flangeThickness * 2 >= dimensions.webHeight) {
+        errors.push('フランジ厚さが大きすぎます');
+      }
+      break;
+    case 'l-angle':
+      if (!dimensions.legA || dimensions.legA <= 0) {
+        errors.push('辺Aは正の値を入力してください');
+      }
+      if (!dimensions.legB || dimensions.legB <= 0) {
+        errors.push('辺Bは正の値を入力してください');
+      }
+      if (!dimensions.legThickness || dimensions.legThickness <= 0) {
+        errors.push('厚さは正の値を入力してください');
+      }
+      if (dimensions.legThickness && dimensions.legA &&
+          dimensions.legThickness >= dimensions.legA) {
+        errors.push('厚さは辺Aより小さくしてください');
+      }
+      if (dimensions.legThickness && dimensions.legB &&
+          dimensions.legThickness >= dimensions.legB) {
+        errors.push('厚さは辺Bより小さくしてください');
+      }
+      break;
+    case 'channel':
+      if (!dimensions.channelWidth || dimensions.channelWidth <= 0) {
+        errors.push('幅は正の値を入力してください');
+      }
+      if (!dimensions.channelHeight || dimensions.channelHeight <= 0) {
+        errors.push('高さは正の値を入力してください');
+      }
+      if (!dimensions.channelFlangeThickness || dimensions.channelFlangeThickness <= 0) {
+        errors.push('フランジ厚さは正の値を入力してください');
+      }
+      if (!dimensions.channelWebThickness || dimensions.channelWebThickness <= 0) {
+        errors.push('ウェブ厚さは正の値を入力してください');
+      }
+      break;
+  }
+
+  return errors;
+}
+
+// カスタムフック
+export function useSectionCalculator(): UseSectionCalculatorReturn {
+  const [shapeType, setShapeType] = useState<SectionShapeType>('circle');
+  const [dimensions, setDimensions] = useState<SectionDimensions>({
+    diameter: 100,
+  });
+
+  const updateDimension = useCallback((key: keyof SectionDimensions, value: number) => {
+    setDimensions(prev => ({
+      ...prev,
+      [key]: value,
+    }));
+  }, []);
+
+  const validationErrors = useMemo(
+    () => validateDimensions(shapeType, dimensions),
+    [shapeType, dimensions]
+  );
+
+  const isValid = validationErrors.length === 0;
+
+  const properties = useMemo(() => {
+    if (!isValid) return null;
+    return calculateSectionProperties(shapeType, dimensions);
+  }, [shapeType, dimensions, isValid]);
+
+  // 形状タイプ変更時にデフォルト寸法をセット
+  const handleSetShapeType = useCallback((type: SectionShapeType) => {
+    setShapeType(type);
+    switch (type) {
+      case 'circle':
+        setDimensions({ diameter: 100 });
+        break;
+      case 'pipe':
+        setDimensions({ outerDiameter: 100, innerDiameter: 80 });
+        break;
+      case 'rectangle':
+        setDimensions({ width: 100, height: 200 });
+        break;
+      case 'box':
+        setDimensions({ outerWidth: 100, outerHeight: 200, thickness: 10 });
+        break;
+      case 'h-beam':
+        setDimensions({
+          flangeWidth: 200,
+          webHeight: 400,
+          flangeThickness: 16,
+          webThickness: 10,
+        });
+        break;
+      case 'l-angle':
+        setDimensions({ legA: 100, legB: 100, legThickness: 10 });
+        break;
+      case 'channel':
+        setDimensions({
+          channelWidth: 75,
+          channelHeight: 150,
+          channelFlangeThickness: 10,
+          channelWebThickness: 6,
+        });
+        break;
+    }
+  }, []);
+
+  return {
+    shapeType,
+    setShapeType: handleSetShapeType,
+    dimensions,
+    setDimensions,
+    updateDimension,
+    properties,
+    isValid,
+    validationErrors,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,5 +69,72 @@ export interface PDFFileInfo {
   pages: number;
 }
 
+// Section Property Calculator Types
+export type SectionShapeType =
+  | 'circle'        // 丸
+  | 'pipe'          // 丸パイプ
+  | 'rectangle'     // 四角
+  | 'box'           // 角パイプ
+  | 'h-beam'        // H型
+  | 'l-angle'       // L型
+  | 'channel';      // 溝型
+
+export interface SectionDimensions {
+  // 円形断面 (circle)
+  diameter?: number;          // 直径 D
+
+  // 丸パイプ (pipe)
+  outerDiameter?: number;     // 外径 D
+  innerDiameter?: number;     // 内径 d
+
+  // 矩形断面 (rectangle)
+  width?: number;             // 幅 B
+  height?: number;            // 高さ H
+
+  // 角パイプ (box)
+  outerWidth?: number;        // 外幅 B
+  outerHeight?: number;       // 外高さ H
+  innerWidth?: number;        // 内幅 b
+  innerHeight?: number;       // 内高さ h
+  thickness?: number;         // 板厚 t
+
+  // H型 (h-beam)
+  flangeWidth?: number;       // フランジ幅 B
+  webHeight?: number;         // ウェブ高さ H
+  flangeThickness?: number;   // フランジ厚さ tf
+  webThickness?: number;      // ウェブ厚さ tw
+
+  // L型 (l-angle)
+  legA?: number;              // 辺A
+  legB?: number;              // 辺B
+  legThickness?: number;      // 厚さ t
+
+  // 溝型 (channel)
+  channelWidth?: number;      // 幅 B
+  channelHeight?: number;     // 高さ H
+  channelFlangeThickness?: number;  // フランジ厚さ tf
+  channelWebThickness?: number;     // ウェブ厚さ tw
+}
+
+export interface SectionProperties {
+  area: number;               // 断面積 A (mm²)
+  momentOfInertiaX: number;   // 断面2次モーメント Ix (mm⁴)
+  momentOfInertiaY: number;   // 断面2次モーメント Iy (mm⁴)
+  radiusOfGyrationX: number;  // 断面2次半径 ix (mm)
+  radiusOfGyrationY: number;  // 断面2次半径 iy (mm)
+  sectionModulusX: number;    // 断面係数 Zx (mm³)
+  sectionModulusY: number;    // 断面係数 Zy (mm³)
+  centroidX?: number;         // 図心位置 Cx (mm) - L型、溝型用
+  centroidY?: number;         // 図心位置 Cy (mm) - L型、溝型用
+}
+
+export interface StandardSection {
+  id: string;
+  name: string;
+  type: SectionShapeType;
+  dimensions: SectionDimensions;
+  properties: SectionProperties;
+}
+
 // Common App Types
-export type AppTab = 'matrix' | 'figure' | 'pdf' | 'markdown' | 'boring';
+export type AppTab = 'matrix' | 'figure' | 'pdf' | 'markdown' | 'boring' | 'section';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new structural section properties tool with routing, UI, calculations, and standard datasets.
> 
> - New `SectionPropertyCalculator` app: shape selection, dimension inputs, SVG diagram (`SectionDiagram`), and results (`ResultsDisplay`)
> - Calculation hook `useSectionCalculator` with validation and property formulas for `circle`, `pipe`, `rectangle`, `box`, `h-beam`, `l-angle`, `channel`
> - Searchable `StandardSectionList` with predefined specs in `standardSections.ts`
> - App wiring: navigation updates with `Ruler` icon, new `/section` route/tab (`App.tsx`, `Navigation.tsx`)
> - Types extended in `types/index.ts` for section dimensions/properties and `AppTab`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c69467ea504af7193a4d1555bd6e62aeef6d5e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->