### PR TITLE
地盤検索に「東京の地盤(GIS版)」を横断検索ソースとして追加

### DIFF
--- a/server.js
+++ b/server.js
@@ -90,6 +90,37 @@ app.get('/api/kunijiban', async (req, res) => {
   }
 })
 
+// 東京の地盤(GIS版) ローカル地盤API への薄いリバースプロキシ。
+// jiban-api は別コンテナ（同一Dockerネットワーク）。ブラウザからは minitools
+// 同一オリジンの /api/tokyo/* で叩けるので Mixed Content / CORS が発生しない。
+// JIBAN_API_URL 未設定なら東京機能は無効（503）＝MLIT単独でも動作する。
+const JIBAN_API_URL = process.env.JIBAN_API_URL // 例: http://jiban-api:8000
+app.use('/api/tokyo', async (req, res) => {
+  if (!JIBAN_API_URL) {
+    return res.status(503).json({ error: 'Tokyo jiban API not configured' })
+  }
+  try {
+    const target = JIBAN_API_URL.replace(/\/$/, '') + req.originalUrl.replace(/^\/api\/tokyo/, '')
+    const upstream = await fetch(target, {
+      method: req.method,
+      headers: { accept: req.headers['accept'] || '*/*' },
+    })
+    res.status(upstream.status)
+    const ct = upstream.headers.get('content-type')
+    if (ct) res.setHeader('Content-Type', ct)
+    const cc = upstream.headers.get('cache-control')
+    if (cc) res.setHeader('Cache-Control', cc)
+    const buf = Buffer.from(await upstream.arrayBuffer())
+    return res.send(buf)
+  } catch (error) {
+    console.error('Tokyo jiban proxy error:', error)
+    return res.status(502).json({
+      error: 'Bad gateway to jiban API',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
+  }
+})
+
 // Static assets + SPA fallback (final middleware works across Express 4/5).
 const distDir = path.join(__dirname, 'dist')
 app.use(express.static(distDir))

--- a/src/components/boring/BoringDataApp.tsx
+++ b/src/components/boring/BoringDataApp.tsx
@@ -5,7 +5,7 @@ import SearchPanel from './SearchPanel';
 import ResultsList from './ResultsList';
 import BoringLogViewer from './BoringLogViewer';
 import {
-  searchByLocation,
+  searchAllSources,
   generateMockSearchResults,
   generateMockBoringData,
   fetchAndParseBoringData,
@@ -102,8 +102,15 @@ const BoringDataApp: React.FC<BoringDataAppProps> = ({ onSuccess, onError }) => 
         await new Promise(resolve => setTimeout(resolve, 500)); // 擬似的な遅延
         results = generateMockSearchResults(area.center, 8);
       } else {
-        // 本番モード: サーバーレス関数経由でMLIT APIを使用
-        results = await searchByLocation(area, keyword, 50);
+        // 本番モード: MLIT(国土地盤) と 東京の地盤(GIS版) を横断検索してマージ
+        const { results: merged, errors } = await searchAllSources(area, keyword, 50);
+        results = merged;
+        // 片方のソースだけ失敗した場合は警告として通知（結果は表示する）
+        if (errors.length > 0 && merged.length > 0) {
+          onError?.(`一部ソースの検索に失敗しました（${errors.join(' / ')}）`);
+        } else if (errors.length > 0) {
+          throw new Error(errors.join(' / '));
+        }
       }
 
       setSearchResults(results);
@@ -112,7 +119,9 @@ const BoringDataApp: React.FC<BoringDataAppProps> = ({ onSuccess, onError }) => 
       if (results.length === 0) {
         onError?.('指定した範囲にボーリングデータが見つかりませんでした');
       } else {
-        onSuccess?.(`${results.length}件のボーリングデータが見つかりました`);
+        const tokyoCount = results.filter(r => r.source === 'tokyo').length;
+        const mlitCount = results.length - tokyoCount;
+        onSuccess?.(`${results.length}件見つかりました（国土地盤 ${mlitCount} / 東京 ${tokyoCount}）`);
       }
     } catch (err) {
       setSearchStatus('error');

--- a/src/components/boring/MapView.tsx
+++ b/src/components/boring/MapView.tsx
@@ -26,6 +26,19 @@ const boringIcon = new L.Icon({
   popupAnchor: [0, -12],
 });
 
+// 東京の地盤(GIS版) 地点用アイコン（オレンジでMLITと区別）
+const tokyoBoringIcon = new L.Icon({
+  iconUrl: 'data:image/svg+xml;base64,' + btoa(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+      <circle cx="12" cy="12" r="10" fill="#f59e0b" stroke="#fff" stroke-width="2"/>
+      <circle cx="12" cy="12" r="4" fill="#fff"/>
+    </svg>
+  `),
+  iconSize: [24, 24],
+  iconAnchor: [12, 12],
+  popupAnchor: [0, -12],
+});
+
 // 選択中のボーリング地点用アイコン
 const selectedBoringIcon = new L.Icon({
   iconUrl: 'data:image/svg+xml;base64,' + btoa(`
@@ -177,7 +190,7 @@ const MapView: React.FC<MapViewProps> = ({
             <Marker
               key={result.id}
               position={[result.location.lat, result.location.lng]}
-              icon={isSelected ? selectedBoringIcon : boringIcon}
+              icon={isSelected ? selectedBoringIcon : (result.source === 'tokyo' ? tokyoBoringIcon : boringIcon)}
               eventHandlers={{
                 click: () => onResultSelect(result),
               }}
@@ -185,6 +198,13 @@ const MapView: React.FC<MapViewProps> = ({
               <Popup>
                 <div className="text-sm min-w-[200px]">
                   <p className="font-medium text-gray-900">{result.title}</p>
+                  <span
+                    className={`inline-block mt-1 px-1.5 py-0.5 rounded text-xs text-white ${
+                      result.source === 'tokyo' ? 'bg-amber-500' : 'bg-red-500'
+                    }`}
+                  >
+                    {result.source === 'tokyo' ? '東京の地盤(GIS版)' : '国土地盤'}
+                  </span>
                   {result.description && (
                     <p className="text-gray-600 mt-1">{result.description}</p>
                   )}
@@ -216,7 +236,11 @@ const MapView: React.FC<MapViewProps> = ({
           </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 rounded-full bg-red-500 border border-white shadow"></div>
-            <span className="text-gray-700 dark:text-gray-300">ボーリング地点</span>
+            <span className="text-gray-700 dark:text-gray-300">国土地盤(KuniJiban)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-amber-500 border border-white shadow"></div>
+            <span className="text-gray-700 dark:text-gray-300">東京の地盤(GIS版)</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 rounded-full bg-blue-500 border-2 border-white shadow"></div>

--- a/src/components/boring/api.ts
+++ b/src/components/boring/api.ts
@@ -259,6 +259,100 @@ export async function searchByKeyword(
   });
 }
 
+// ============================================================
+// 東京の地盤(GIS版) ローカル地盤API 連携
+// ローカルDokployの jiban-api を minitools 同一オリジンの
+// /api/tokyo/* プロキシ経由で叩く（Mixed Content/CORS回避）。
+// 検索結果は MLITSearchResult 形に正規化して MLIT と横断マージする。
+// ============================================================
+const TOKYO_API_BASE = '/api/tokyo';
+
+interface TokyoSearchItem {
+  id: string;            // 地点ID（例: TKY-12345）
+  title: string;         // 調査名/地点名
+  lat: number;           // 十進緯度（取り込み時に度分秒→十進変換済み）
+  lng: number;           // 十進経度
+  xml_url: string;       // bed.xml の配信パス（同一オリジン /api/tokyo/files/...）
+  pdf_url?: string;      // bed.pdf の配信パス（任意）
+  address?: string;
+  survey_finish?: string;
+}
+
+interface TokyoSearchResponse {
+  total: number;
+  results: TokyoSearchItem[];
+}
+
+// 東京データの位置検索（jiban-api /search）
+export async function searchTokyo(
+  area: SearchArea,
+  size: number = 50
+): Promise<MLITSearchResult[]> {
+  const params = new URLSearchParams({
+    lat: String(area.center.lat),
+    lng: String(area.center.lng),
+    radius: String(area.radius),
+    size: String(size),
+  });
+
+  const response = await fetch(`${TOKYO_API_BASE}/search?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`東京地盤API エラー: ${response.status} ${response.statusText}`);
+  }
+
+  const data: TokyoSearchResponse = await response.json();
+
+  return data.results.map(item => ({
+    id: item.id,
+    title: item.title,
+    source: 'tokyo' as const,
+    metadata: {
+      'NGI:latitude': String(item.lat),
+      'NGI:longitude': String(item.lng),
+      'NGI:address': item.address,
+      'NGI:survey_finish': item.survey_finish,
+      // 詳細取得は共通の link_boring_xml 経路に乗せる（同一オリジンの配信パス）
+      'NGI:link_boring_xml': item.xml_url,
+      'NGI:link_boring_pdf': item.pdf_url,
+    },
+    location: { lat: item.lat, lng: item.lng },
+    datasetName: '東京の地盤(GIS版)',
+    catalogName: 'CC BY 2.1 JP',
+  }));
+}
+
+// MLIT + 東京を横断検索してマージ
+// どちらか一方が失敗しても、もう一方の結果は返す（部分成功を許容）。
+export async function searchAllSources(
+  area: SearchArea,
+  keyword?: string,
+  size: number = 50
+): Promise<{ results: MLITSearchResult[]; errors: string[] }> {
+  const errors: string[] = [];
+
+  const [mlitSettled, tokyoSettled] = await Promise.allSettled([
+    searchByLocation(area, keyword, size),
+    searchTokyo(area, size),
+  ]);
+
+  const results: MLITSearchResult[] = [];
+
+  if (mlitSettled.status === 'fulfilled') {
+    // 既存MLIT結果には source を明示付与（未指定=mlit）
+    results.push(...mlitSettled.value.map(r => ({ ...r, source: 'mlit' as const })));
+  } else {
+    errors.push(`MLIT: ${mlitSettled.reason?.message ?? mlitSettled.reason}`);
+  }
+
+  if (tokyoSettled.status === 'fulfilled') {
+    results.push(...tokyoSettled.value);
+  } else {
+    errors.push(`東京: ${tokyoSettled.reason?.message ?? tokyoSettled.reason}`);
+  }
+
+  return { results, errors };
+}
+
 // XMLパーサー: ボーリングデータを解析（DTD version 2.10/3.00/4.00対応）
 export function parseBoringXML(xmlString: string, id: string, location: GeoLocation): BoringData {
   const parser = new DOMParser();
@@ -351,8 +445,11 @@ export async function fetchAndParseBoringData(
   location: GeoLocation
 ): Promise<BoringData> {
   try {
-    // CORS問題を回避するため、サーバーレス関数経由でXMLを取得
-    const fetchUrl = `/api/kunijiban?url=${encodeURIComponent(xmlUrl)}`;
+    // 東京データ(/api/tokyo/files/...)は同一オリジン配信なので直fetch。
+    // KuniJiban(外部https)はCORS回避のためサーバーレス関数経由で取得。
+    const fetchUrl = xmlUrl.startsWith('/api/tokyo/')
+      ? xmlUrl
+      : `/api/kunijiban?url=${encodeURIComponent(xmlUrl)}`;
 
     const response = await fetch(fetchUrl);
 

--- a/src/components/boring/types.ts
+++ b/src/components/boring/types.ts
@@ -15,10 +15,17 @@ export interface SearchArea {
   radius: number; // メートル単位
 }
 
+// データソース種別
+// 'mlit'  … 国土地盤情報(KuniJiban) ＝ MLIT DPF GraphQL API
+// 'tokyo' … 東京の地盤(GIS版) ＝ ローカルDokployの地盤API(/api/tokyo)
+export type DataSource = 'mlit' | 'tokyo';
+
 // MLIT DPF API レスポンスの検索結果
 export interface MLITSearchResult {
   id: string;
   title: string;
+  // 検索結果の出自。未指定は既存挙動(=mlit)とみなす
+  source?: DataSource;
   metadata?: {
     'NGI:id'?: string;
     'NGI:code'?: string;


### PR DESCRIPTION
既存の地盤検索ツール（`src/components/boring/`）を拡張し、MLIT(国土地盤) に加えて **東京の地盤(GIS版) 約29,484地点** を地図クリックで横断検索できるようにします。バックエンドは別リポジトリ [ymzkd/jiban-api](https://github.com/ymzkd/jiban-api)（FastAPI, Dokployデプロイ済み）。

## 変更点
- **types.ts**: `DataSource('mlit'|'tokyo')` と `source` フィールド追加
- **api.ts**: `searchTokyo()` / `searchAllSources()`（MLITと東京を並列検索しマージ、片方失敗は許容）。東京の詳細XMLは同一オリジン `/api/tokyo/files/*` を直fetchし、**既存の v4.0 BEDパーサで柱状図描画**（東京データはBED0400=v4.0、実データでタグ一致を確認済み）
- **BoringDataApp.tsx**: 横断検索マージ＋件数を「国土地盤 N / 東京 N」表示
- **MapView.tsx**: 東京地点を橙マーカーで色分け、凡例・ポップアップに出典バッジ
- **server.js**: `/api/tokyo/*` → `jiban-api` への薄いリバースプロキシ（同一オリジン化でCORS/Mixed Content回避。`JIBAN_API_URL` 未設定なら503でMLIT単独動作）

## デプロイに必要な設定
- minitools の環境変数に `JIBAN_API_URL=http://jiban-api-hfwtz5:8000` を追加（UIで設定）
- 出典表記: 東京の地盤(GIS版) CC BY 2.1 JP（無改変・著作権非主張）

🤖 Generated with [Claude Code](https://claude.com/claude-code)