### PR TITLE
東京データの詳細表示拡充＋PDF柱状図ボタン

### DIFF
--- a/src/components/boring/BoringLogViewer.tsx
+++ b/src/components/boring/BoringLogViewer.tsx
@@ -87,6 +87,21 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
         </button>
       </div>
 
+      {/* PDF柱状図（元データの柱状図PDF）をいつでも開ける。東京の地盤は全点PDF有り */}
+      {selectedResult.metadata?.['NGI:link_boring_pdf'] && (
+        <div className="px-4 pt-3">
+          <a
+            href={selectedResult.metadata['NGI:link_boring_pdf']}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors text-sm font-medium"
+          >
+            <FileText className="w-4 h-4" />
+            PDF柱状図を開く
+          </a>
+        </div>
+      )}
+
       {/* ローディング */}
       {loading && (
         <div className="p-8 text-center">
@@ -128,10 +143,16 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
               <FileText className="w-4 h-4" />
               <span>掘削深度: {data.depth.toFixed(1)}m</span>
             </div>
-            {selectedResult.metadata?.['NGI:boring_elevation'] && (
+            {(selectedResult.metadata?.['NGI:boring_elevation'] || data.groundElevation !== undefined) && (
               <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
                 <Mountain className="w-4 h-4" />
-                <span>孔口標高: {selectedResult.metadata['NGI:boring_elevation']}m</span>
+                <span>孔口標高: {selectedResult.metadata?.['NGI:boring_elevation'] ?? data.groundElevation?.toFixed(2)}m</span>
+              </div>
+            )}
+            {data.purpose && (
+              <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400 col-span-2">
+                <FileText className="w-4 h-4" />
+                <span>調査目的: {data.purpose}</span>
               </div>
             )}
             {selectedResult.metadata?.['NGI:boring_xml_version'] && (

--- a/src/components/boring/api.ts
+++ b/src/components/boring/api.ts
@@ -307,6 +307,7 @@ export async function searchTokyo(
     title: item.title,
     source: 'tokyo' as const,
     metadata: {
+      'NGI:code': item.id,
       'NGI:latitude': String(item.lat),
       'NGI:longitude': String(item.lng),
       'NGI:address': item.address,
@@ -377,11 +378,14 @@ export function parseBoringXML(xmlString: string, id: string, location: GeoLocat
 
   // 基本情報の取得（標題情報セクション - 全バージョン共通）
   const title = getText('調査名', undefined, xmlDoc) || getText('工事名', undefined, xmlDoc) || `ボーリング ${id}`;
-  const depth = getNumber('総掘進長', undefined, xmlDoc) || getNumber('孔底深度', undefined, xmlDoc) || 0;
+  // 掘削深度: KuniJibanは総掘進長/孔底深度、東京の地盤(BED0400)は総削孔長
+  const depth = getNumber('総掘進長', undefined, xmlDoc) || getNumber('孔底深度', undefined, xmlDoc) || getNumber('総削孔長', undefined, xmlDoc) || 0;
   const surveyEnd = getText('調査期間_終了年月日', undefined, xmlDoc);
   const surveyStart = getText('調査期間_開始年月日', undefined, xmlDoc);
   const date = surveyEnd || surveyStart;
-  const organization = getText('調査会社_名称', undefined, xmlDoc) || getText('発注機関_名称', undefined, xmlDoc);
+  const organization = getText('調査会社_名称', undefined, xmlDoc) || getText('発注機関_名称', undefined, xmlDoc) || getText('発注機関名称', undefined, xmlDoc);
+  const groundElevation = getNumber('孔口標高', undefined, xmlDoc);
+  const purpose = getText('調査目的', undefined, xmlDoc);
 
   // 土質層データの取得（バージョン別パーサーを使用）
   const layers = soilLayerParser.parseSoilLayers(xmlDoc);
@@ -434,6 +438,8 @@ export function parseBoringXML(xmlString: string, id: string, location: GeoLocat
     layers,
     standardPenetrationTests: sptTests.length > 0 ? sptTests : undefined,
     waterLevel,
+    groundElevation: groundElevation || undefined,
+    purpose: purpose || undefined,
     dtdVersion,
   };
 }

--- a/src/components/boring/types.ts
+++ b/src/components/boring/types.ts
@@ -70,6 +70,8 @@ export interface BoringData {
   layers: SoilLayer[];
   standardPenetrationTests?: SPTData[];
   waterLevel?: number; // 地下水位
+  groundElevation?: number; // 孔口標高（m）
+  purpose?: string; // 調査目的
   pdfUrl?: string; // PDF柱状図のURL
   xmlUrl?: string; // XMLデータのURL
   dtdVersion?: DTDVersion; // DTDバージョン


### PR DESCRIPTION
ユーザ指摘（東京データの情報が少ない／PDFを開きたい）への対応。実データ集計で「掘削深度・孔口標高は有るのに未表示／別タグで0表示」「調査会社名・発注機関は元データが空(0%)」と判明したため、表示できる項目を拾い切る。

## 変更
- **PDF柱状図を開くボタン**を詳細パネルに追加（`/api/tokyo/files/<id>_bed.pdf`、東京は全29,484点でPDF有り）。parse成否に関わらず常時表示
- **掘削深度**: パーサに `総削孔長` フォールバック追加（東京はBED0400で総削孔長を使用→従来の0表示を解消）
- **孔口標高(100%)・調査目的(63%)** を `parseBoringXML` で抽出し `BoringData` に追加、詳細に表示
- 東京結果に `NGI:code`(ボーリングID) を付与

## 既知の制約（データ起因・修正不可）
東京都地盤DBは **調査会社名・発注機関名を保持していない(充足率0%)** ため、KuniJibanのような会社名表示は出ません（件名も多くが"東京都地盤DB"）。掘削深度・孔口標高・地下水位・調査目的・土質柱状図・N値は表示されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)