### PR TITLE
フィードバック対応: フッターに東京の地盤追加＋柱状図ボタン位置の統一

### DIFF
--- a/src/components/boring/BoringDataApp.tsx
+++ b/src/components/boring/BoringDataApp.tsx
@@ -305,6 +305,16 @@ const BoringDataApp: React.FC<BoringDataAppProps> = ({ onSuccess, onError }) => 
           >
             国土地盤情報検索サイト (KuniJiban)
           </a>
+          {' / '}
+          <a
+            href="https://www.kensetsu.metro.tokyo.lg.jp/jimusho/tech/geo-web"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline"
+          >
+            東京の地盤(GIS版)
+          </a>
+          <span className="ml-1">（東京都建設局 / CC BY 2.1 JP）</span>
         </p>
       </div>
     </div>

--- a/src/components/boring/BoringLogViewer.tsx
+++ b/src/components/boring/BoringLogViewer.tsx
@@ -87,21 +87,6 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
         </button>
       </div>
 
-      {/* PDF柱状図（元データの柱状図PDF）をいつでも開ける。東京の地盤は全点PDF有り */}
-      {selectedResult.metadata?.['NGI:link_boring_pdf'] && (
-        <div className="px-4 pt-3">
-          <a
-            href={selectedResult.metadata['NGI:link_boring_pdf']}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors text-sm font-medium"
-          >
-            <FileText className="w-4 h-4" />
-            PDF柱状図を開く
-          </a>
-        </div>
-      )}
-
       {/* ローディング */}
       {loading && (
         <div className="p-8 text-center">
@@ -165,6 +150,18 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
 
           {/* 外部リンク */}
           <div className="flex flex-wrap gap-2">
+            {/* 柱状図表示（東京の地盤=PDF原本 / 国土地盤=外部ビューア）を同じ位置・スタイルで提供 */}
+            {selectedResult.metadata?.['NGI:link_boring_pdf'] && (
+              <a
+                href={selectedResult.metadata['NGI:link_boring_pdf']}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm font-medium"
+              >
+                <ExternalLink className="w-4 h-4" />
+                PDF柱状図を表示
+              </a>
+            )}
             {/* 外部ビューアーリンク */}
             {ngiId && (
               <a


### PR DESCRIPTION
## 対応
1. **フッターのデータソース一覧に「東京の地盤(GIS版)」を追加**（[東京都建設局 土木技術支援センター](https://www.kensetsu.metro.tokyo.lg.jp/jimusho/tech/geo-web) / CC BY 2.1 JP 表記付き）
2. **柱状図ボタンの位置統一**: 東京データのPDFボタンが、国土地盤(KuniJiban)の「外部サイトで柱状図を表示」と異なる位置（ヘッダ直下）にあり使いにくかったのを、**同じ「外部リンク」欄の先頭・同じ青スタイル**に統一。ラベルは「PDF柱状図を表示」。検索結果は東京 or 国土地盤のどちらか一方なので、両ソースでボタンが同一位置に出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)