### PR TITLE
feat(hazard): 積雪オーバーレイのループ切替＋特定行政庁の分布/所管庁表示

### DIFF
--- a/src/components/hazard/HazardMap.tsx
+++ b/src/components/hazard/HazardMap.tsx
@@ -8,7 +8,7 @@ interface LatLng {
   lng: number;
 }
 
-export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth' | 'snow_zones';
+export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth' | 'snow_zones' | 'authority';
 
 interface HazardMapProps {
   center: LatLng; // マーカー＋海率円の中心（地図クリックでも更新される）
@@ -76,6 +76,27 @@ const URBAN_PMTILES = '/api/design/tiles/urban_areas.pmtiles';
 const URBAN_SOURCE_LAYER = 'urban';
 const URBAN_FILL_COLOR = '#9ca3af'; // gray-400
 
+// 特定行政庁(建築基準法)の分布。authority_zones.pmtiles(source-layer='zones')を庁の区分(type)で
+// 4色に塗り分ける。属性は build_authority_geojson.py のフラット属性(p_type/p_name/split/l_name…)。
+const AUTHORITY_PMTILES = '/api/design/tiles/authority_zones.pmtiles';
+const AUTHORITY_SOURCE_LAYER = 'zones';
+// 区分(type)→色。知事=緑 / 建築主事設置市=青 / 限定特定行政庁=橙 / 特別区=紫。
+const AUTHORITY_TYPE_COLOR: maplibregl.ExpressionSpecification = [
+  'match', ['get', 'p_type'],
+  'prefecture', '#66bd63',
+  'city_full', '#3182bd',
+  'city_limited', '#fdae61',
+  'special_ward', '#8856a7',
+  '#bdbdbd',
+];
+// 区分(type)の日本語ラベル（凡例/ホバー用）。
+const AUTHORITY_TYPE_LABEL: Record<string, string> = {
+  prefecture: '都道府県知事',
+  city_full: '建築主事設置市',
+  city_limited: '限定特定行政庁',
+  special_ward: '特別区',
+};
+
 // 地図内オーバーレイ凡例（CSSグラデーション）。地図の塗り色と対応。
 const LEGEND: Record<Exclude<ZoneOverlay, 'none'>, { title: string; grad: string; min: string; max: string }> = {
   wind: {
@@ -112,6 +133,15 @@ const LEGEND: Record<Exclude<ZoneOverlay, 'none'>, { title: string; grad: string
       'linear-gradient(to right,#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,' +
       '#8c564b,#e377c2,#17becf,#bcbd22,#393b79)',
     min: '区分ごとに配色',
+    max: '',
+  },
+  authority: {
+    title: '特定行政庁（建築基準法）',
+    // 庁の区分で色分け（知事=緑 / 主事設置市=青 / 限定=橙 / 特別区=紫）の4色ハードストップ。
+    grad:
+      'linear-gradient(to right,#66bd63 0 25%,#3182bd 25% 50%,' +
+      '#fdae61 50% 75%,#8856a7 75% 100%)',
+    min: '知事 / 市 / 限定 / 特別区',
     max: '',
   },
 };
@@ -264,6 +294,9 @@ const HazardMap: React.FC<HazardMapProps> = ({
     if (map.getLayer('zones-urban-fill')) {
       map.setLayoutProperty('zones-urban-fill', 'visibility', kind === 'urban' ? 'visible' : 'none');
     }
+    if (map.getLayer('zones-authority-fill')) {
+      map.setLayoutProperty('zones-authority-fill', 'visibility', kind === 'authority' ? 'visible' : 'none');
+    }
     if (map.getLayer('zones-depth-fill')) {
       map.setLayoutProperty('zones-depth-fill', 'visibility', kind === 'depth' ? 'visible' : 'none');
     }
@@ -355,6 +388,20 @@ const HazardMap: React.FC<HazardMapProps> = ({
         'source-layer': URBAN_SOURCE_LAYER,
         layout: { visibility: 'none' },
         paint: { 'fill-color': URBAN_FILL_COLOR, 'fill-opacity': 0.45 },
+      });
+
+      // 特定行政庁（建築基準法）の分布。庁の区分(type)で4色に塗り分け。
+      map.addSource('zones-authority', {
+        type: 'vector',
+        url: `pmtiles://${origin}${AUTHORITY_PMTILES}`,
+      });
+      map.addLayer({
+        id: 'zones-authority-fill',
+        type: 'fill',
+        source: 'zones-authority',
+        'source-layer': AUTHORITY_SOURCE_LAYER,
+        layout: { visibility: 'none' },
+        paint: { 'fill-color': AUTHORITY_TYPE_COLOR, 'fill-opacity': 0.5 },
       });
 
       map.addSource('circle', { type: 'geojson', data: EMPTY_FC });
@@ -451,6 +498,19 @@ const HazardMap: React.FC<HazardMapProps> = ({
         if (fs.length) {
           const p = fs[0].properties || {};
           setHover(`積雪区分: 第${p.zone}区 (α${p.alpha} β${p.beta} γ${p.gamma})`);
+        } else {
+          setHover(null);
+        }
+        return;
+      }
+      if (ov === 'authority') {
+        const fs = map.queryRenderedFeatures(e.point, { layers: ['zones-authority-fill'] });
+        if (fs.length) {
+          const p = fs[0].properties || {};
+          const typeLabel = AUTHORITY_TYPE_LABEL[p.p_type as string] ?? '';
+          // 規模分割地点は小規模側(主たる庁)を表示し、大規模側を併記。
+          const large = p.split ? `／大規模:${p.l_name}` : '';
+          setHover(`特定行政庁: ${p.p_name}${typeLabel ? `（${typeLabel}）` : ''}${large}`);
         } else {
           setHover(null);
         }

--- a/src/components/hazard/HazardMap.tsx
+++ b/src/components/hazard/HazardMap.tsx
@@ -8,7 +8,7 @@ interface LatLng {
   lng: number;
 }
 
-export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth';
+export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth' | 'snow_zones';
 
 interface HazardMapProps {
   center: LatLng; // マーカー＋海率円の中心（地図クリックでも更新される）
@@ -23,10 +23,23 @@ interface HazardMapProps {
 
 // ゾーン番号→色。色が濃いほど区分番号が大きい（元アプリと同じ向き）。薄く重ねる。
 // 積雪は青系(第1〜40区)、風速は赤系(第1〜9区)。
-const ZONE_FILL_COLOR: Record<'wind' | 'seismic', maplibregl.ExpressionSpecification> = {
+const ZONE_FILL_COLOR: Record<'wind' | 'seismic' | 'snow_zones', maplibregl.ExpressionSpecification> = {
   wind: ['interpolate', ['linear'], ['get', 'zone'], 1, '#fee5d9', 5, '#fb6a4a', 9, '#a50f15'],
   // 地震地域係数 Z（大きいほど地震荷重が大）。Z=0.7淡 → 1.0濃赤。
   seismic: ['interpolate', ['linear'], ['get', 'Z'], 0.7, '#fee08b', 0.8, '#fdae61', 0.9, '#f46d43', 1.0, '#d73027'],
+  // 積雪荷重の地域区分（平12建告1455号、第0〜40区）。連続値ではなく離散区分なので、
+  // 隣り合う区が必ず別色になるよう高コントラスト10色を zone%10 で循環割当する。
+  // 第0区＝積雪なしは中立グレー。zone は離散なので match（補間しない）。
+  snow_zones: [
+    'match', ['get', 'zone'],
+    0, '#d9d9d9',
+    [
+      'match', ['%', ['get', 'zone'], 10],
+      0, '#1f77b4', 1, '#ff7f0e', 2, '#2ca02c', 3, '#d62728', 4, '#9467bd',
+      5, '#8c564b', 6, '#e377c2', 7, '#17becf', 8, '#bcbd22', 9, '#393b79',
+      '#888888',
+    ],
+  ] as unknown as maplibregl.ExpressionSpecification,
 };
 
 // 積雪深は「値ラスター」: タイルは d[cm] を terrarium 標高エンコードで格納。maplibre v5 の
@@ -49,10 +62,13 @@ const DEPTH_RELIEF_COLOR = [
 
 // ベクタタイル(区分)とラスタータイル(積雪深)の同一オリジン取得パス。jiban-api
 // /design/tiles を minitools の Express が Range 転送する。
-const ZONE_PMTILES: Record<'wind' | 'seismic', string> = {
+const ZONE_PMTILES: Record<'wind' | 'seismic' | 'snow_zones', string> = {
   wind: '/api/design/tiles/wind_zones.pmtiles',
   seismic: '/api/design/tiles/seismic_zones.pmtiles',
+  snow_zones: '/api/design/tiles/snow_zones.pmtiles',
 };
+// init で生成するベクタ区分レイヤ一覧（source-layer はいずれも 'zones'）。
+const VECTOR_ZONE_KINDS = ['wind', 'seismic', 'snow_zones'] as const;
 const ZONE_SOURCE_LAYER = 'zones';
 const DEPTH_PMTILES = '/api/design/tiles/snow_depth.pmtiles';
 // 都市計画区域(外形のみ)。区域区分は区別せずグレー塗りで分布を示す。tippecanoe -l urban。
@@ -88,6 +104,15 @@ const LEGEND: Record<Exclude<ZoneOverlay, 'none'>, { title: string; grad: string
       'rgba(106,30,140,0.92) 80%,rgba(74,20,80,0.95) 100%)',
     min: '0',
     max: '1500',
+  },
+  snow_zones: {
+    title: '積雪 地域区分（平12建告1455号）',
+    // 区分ごとに色分け（連続スケールではない）。帯は多色で「カテゴリ配色」であることを示す。
+    grad:
+      'linear-gradient(to right,#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,' +
+      '#8c564b,#e377c2,#17becf,#bcbd22,#393b79)',
+    min: '区分ごとに配色',
+    max: '',
   },
 };
 
@@ -233,6 +258,9 @@ const HazardMap: React.FC<HazardMapProps> = ({
     if (map.getLayer('zones-seismic-fill')) {
       map.setLayoutProperty('zones-seismic-fill', 'visibility', kind === 'seismic' ? 'visible' : 'none');
     }
+    if (map.getLayer('zones-snow_zones-fill')) {
+      map.setLayoutProperty('zones-snow_zones-fill', 'visibility', kind === 'snow_zones' ? 'visible' : 'none');
+    }
     if (map.getLayer('zones-urban-fill')) {
       map.setLayoutProperty('zones-urban-fill', 'visibility', kind === 'urban' ? 'visible' : 'none');
     }
@@ -282,7 +310,7 @@ const HazardMap: React.FC<HazardMapProps> = ({
       // ゾーン区分オーバーレイ（GSIタイルの上・解析円の下に薄く重ねる）。初期は非表示。
       // PMTilesベクタソースを2種(積雪/風速)。可視になったタイルだけ Range 取得される。
       const origin = window.location.origin;
-      (['wind', 'seismic'] as const).forEach((kind) => {
+      VECTOR_ZONE_KINDS.forEach((kind) => {
         map.addSource(`zones-${kind}`, {
           type: 'vector',
           url: `pmtiles://${origin}${ZONE_PMTILES[kind]}`,
@@ -416,6 +444,16 @@ const HazardMap: React.FC<HazardMapProps> = ({
       if (ov === 'urban') {
         const fs = map.queryRenderedFeatures(e.point, { layers: ['zones-urban-fill'] });
         setHover(fs.length ? '都市計画区域: 区域内' : '都市計画区域: 区域外');
+        return;
+      }
+      if (ov === 'snow_zones') {
+        const fs = map.queryRenderedFeatures(e.point, { layers: ['zones-snow_zones-fill'] });
+        if (fs.length) {
+          const p = fs[0].properties || {};
+          setHover(`積雪区分: 第${p.zone}区 (α${p.alpha} β${p.beta} γ${p.gamma})`);
+        } else {
+          setHover(null);
+        }
         return;
       }
       // depth: 非同期デコード（古い応答は token で破棄）

--- a/src/components/hazard/HazardMapApp.tsx
+++ b/src/components/hazard/HazardMapApp.tsx
@@ -5,13 +5,30 @@ import type { ZoneOverlay } from './HazardMap';
 import { fetchDesign, fetchElevation, geocode, reverseGeocode, snowDepthCm } from './api';
 import type { DesignResult } from './api';
 
-// 地図上のオーバーレイ切替アイコン
-const OVERLAY_ITEMS: { val: ZoneOverlay; Icon: React.ComponentType<{ className?: string }>; label: string }[] = [
-  { val: 'none', Icon: EyeOff, label: 'オフ' },
-  { val: 'wind', Icon: Wind, label: '風速区分' },
-  { val: 'seismic', Icon: Activity, label: '地震地域係数' },
-  { val: 'depth', Icon: Snowflake, label: '積雪深マップ' },
-  { val: 'urban', Icon: Building2, label: '都市計画区域' },
+// 地図上のオーバーレイ切替アイコン。カテゴリごとに1つのアイコンを持ち、同じアイコンを
+// 押すたびに category 内の variant をループで巡回する（例: 積雪アイコン → 積雪深 →
+// 積雪地域区分 → 積雪深 …）。「オフ」だけは独立したボタンとして常に残す。
+type OverlayVariant = Exclude<ZoneOverlay, 'none'>;
+interface OverlayCategory {
+  key: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  label: string; // カテゴリ名（単一 variant のときの既定表示）
+  variants: { val: OverlayVariant; label: string }[];
+}
+const OVERLAY_CATEGORIES: OverlayCategory[] = [
+  { key: 'wind', Icon: Wind, label: '風速区分', variants: [{ val: 'wind', label: '風速区分' }] },
+  { key: 'seismic', Icon: Activity, label: '地震地域係数', variants: [{ val: 'seismic', label: '地震地域係数' }] },
+  {
+    key: 'snow',
+    Icon: Snowflake,
+    label: '積雪',
+    // 押すたびに 積雪深(連続ラスター) ↔ 積雪地域区分(告示の区分ポリゴン) をループ切替。
+    variants: [
+      { val: 'depth', label: '積雪深マップ' },
+      { val: 'snow_zones', label: '積雪地域区分' },
+    ],
+  },
+  { key: 'urban', Icon: Building2, label: '都市計画区域', variants: [{ val: 'urban', label: '都市計画区域' }] },
 ];
 
 interface HazardMapAppProps {
@@ -85,6 +102,16 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
 
   const handleMapPick = useCallback((lat: number, lng: number) => {
     setPoint({ lat, lng });
+  }, []);
+
+  // カテゴリのアイコンを押したときの切替。未選択なら先頭 variant、選択中なら次の
+  // variant をループで巡回する（末尾でオフにはしない）。オフは別ボタンが担当。
+  const cycleCategory = useCallback((cat: OverlayCategory) => {
+    setOverlay((cur) => {
+      const idx = cat.variants.findIndex((v) => v.val === cur);
+      const next = idx === -1 ? 0 : (idx + 1) % cat.variants.length;
+      return cat.variants[next].val;
+    });
   }, []);
 
   // 検索：カンマ区切りの「緯度,経度」ならそこへ移動、そうでなければ住所・地名でジオコーディング。
@@ -350,22 +377,62 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
               onPick={handleMapPick}
             />
             <div className="absolute top-3 left-3 z-[2] flex flex-col gap-1 bg-white/85 dark:bg-gray-800/85 rounded-lg shadow p-1 backdrop-blur-sm">
-              {OVERLAY_ITEMS.map(({ val, Icon, label }) => (
-                <button
-                  key={val}
-                  type="button"
-                  title={label}
-                  aria-label={label}
-                  onClick={() => setOverlay(val)}
-                  className={`inline-flex items-center justify-center w-9 h-9 rounded-md transition-colors ${
-                    overlay === val
-                      ? 'bg-blue-500 text-white'
-                      : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                  }`}
-                >
-                  <Icon className="w-5 h-5" />
-                </button>
-              ))}
+              {/* オフは独立したボタン（カテゴリのループには含めない） */}
+              <button
+                type="button"
+                title="オフ"
+                aria-label="オフ"
+                onClick={() => setOverlay('none')}
+                className={`inline-flex items-center justify-center w-9 h-9 rounded-md transition-colors ${
+                  overlay === 'none'
+                    ? 'bg-blue-500 text-white'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+              >
+                <EyeOff className="w-5 h-5" />
+              </button>
+              {OVERLAY_CATEGORIES.map((cat) => {
+                const activeIdx = cat.variants.findIndex((v) => v.val === overlay);
+                const active = activeIdx !== -1;
+                const multi = cat.variants.length > 1;
+                const curLabel = active ? cat.variants[activeIdx].label : cat.label;
+                const title = multi
+                  ? `${curLabel}（クリックで切替: ${cat.variants.map((v) => v.label).join(' / ')}）`
+                  : cat.label;
+                return (
+                  <button
+                    key={cat.key}
+                    type="button"
+                    title={title}
+                    aria-label={curLabel}
+                    onClick={() => cycleCategory(cat)}
+                    className={`inline-flex flex-col items-center justify-center gap-0.5 w-9 h-9 rounded-md transition-colors ${
+                      active
+                        ? 'bg-blue-500 text-white'
+                        : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    <cat.Icon className="w-5 h-5" />
+                    {/* 複数 variant のカテゴリは現在位置をドットで示し「押すと切替わる」ことを伝える */}
+                    {multi && (
+                      <span className="flex gap-0.5">
+                        {cat.variants.map((v, i) => (
+                          <span
+                            key={v.val}
+                            className={`block w-1 h-1 rounded-full ${
+                              active && i === activeIdx
+                                ? 'bg-white'
+                                : active
+                                  ? 'bg-white/40'
+                                  : 'bg-gray-400/60'
+                            }`}
+                          />
+                        ))}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/hazard/HazardMapApp.tsx
+++ b/src/components/hazard/HazardMapApp.tsx
@@ -1,9 +1,17 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Search, MapPin, TriangleAlert, Snowflake, Wind, Activity, Building2, EyeOff } from 'lucide-react';
+import { Search, MapPin, TriangleAlert, Snowflake, Wind, Activity, Building2, EyeOff, ExternalLink } from 'lucide-react';
 import HazardMap from './HazardMap';
 import type { ZoneOverlay } from './HazardMap';
 import { fetchDesign, fetchElevation, geocode, reverseGeocode, snowDepthCm } from './api';
-import type { DesignResult } from './api';
+import type { DesignResult, Authority, AuthorityType } from './api';
+
+// 特定行政庁の区分(type)の日本語ラベル。
+const AUTHORITY_TYPE_LABEL: Record<AuthorityType, string> = {
+  prefecture: '都道府県知事',
+  city_full: '建築主事設置市',
+  city_limited: '限定特定行政庁',
+  special_ward: '特別区',
+};
 
 // 地図上のオーバーレイ切替アイコン。カテゴリごとに1つのアイコンを持ち、同じアイコンを
 // 押すたびに category 内の variant をループで巡回する（例: 積雪アイコン → 積雪深 →
@@ -28,7 +36,16 @@ const OVERLAY_CATEGORIES: OverlayCategory[] = [
       { val: 'snow_zones', label: '積雪地域区分' },
     ],
   },
-  { key: 'urban', Icon: Building2, label: '都市計画区域', variants: [{ val: 'urban', label: '都市計画区域' }] },
+  {
+    key: 'urban',
+    Icon: Building2,
+    label: '都市計画区域',
+    // 押すたびに 都市計画区域(外形) ↔ 特定行政庁(建築基準法の所管庁分布) をループ切替。
+    variants: [
+      { val: 'urban', label: '都市計画区域' },
+      { val: 'authority', label: '特定行政庁' },
+    ],
+  },
 ];
 
 interface HazardMapAppProps {
@@ -158,6 +175,7 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
   const shore = design?.shore ?? null;
   const seaRatio = design?.sea_ratio ?? null;
   const landRatio = design?.land_ratio ?? null;
+  const building = design?.building_authority ?? null;
 
   // 標高が取れる＝陸とみなす。区域ポリゴン外(海岸線変化の埋立地等)でも、陸なら
   // 最寄り区分(nearest)を採用して計算する。陸と判定できなければ採用しない＝海上扱い。
@@ -183,7 +201,7 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
           Hazard Map
         </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          地図をクリック、または検索ボックスに住所・地名か「緯度,経度」を入力すると、その地点の海率・標高と、建築基準法告示の積雪荷重係数・基準風速・地震地域係数・積雪深を表示します。
+          地図をクリック、または検索ボックスに住所・地名か「緯度,経度」を入力すると、その地点の海率・標高と、建築基準法告示の積雪荷重係数・基準風速・地震地域係数・積雪深、所管する特定行政庁を表示します。
         </p>
       </div>
 
@@ -359,6 +377,38 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
                   </p>
                 )}
               </div>
+
+              {/* 特定行政庁（建築基準法） */}
+              <div>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">
+                  特定行政庁（建築基準法）
+                </h3>
+                {building && (building.all || building.small) ? (
+                  <div className="space-y-2">
+                    {building.split ? (
+                      <>
+                        <AuthorityCard scaleLabel="小規模" sub="法6条1項一〜三号以外の規模" au={building.small} />
+                        <AuthorityCard scaleLabel="大規模" sub="法6条1項一〜三号の規模" au={building.large} />
+                        <p className="text-[11px] text-gray-400">
+                          建築物の規模で所管が分かれる地点です（限定特定行政庁・特別区）。規模の境界は施行令148条/149条の現行条文によります。
+                        </p>
+                      </>
+                    ) : (
+                      <AuthorityCard au={building.all} />
+                    )}
+                    {building.nearest ? (
+                      <p className="text-[11px] text-amber-600 dark:text-amber-500">
+                        区域外のため最寄りの庁を表示（約{building.nearest_km?.toFixed(1)}km）。
+                      </p>
+                    ) : null}
+                    <p className="text-[11px] text-gray-400">
+                      庁区分: 令和7年4月1日現在（全国建築審査会協議会）。URLは参考値のため最終確認は各庁の窓口で。
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-400">取得できませんでした（海上など）</p>
+                )}
+              </div>
             </div>
           </div>
 
@@ -496,5 +546,48 @@ const Row: React.FC<{ k: string; v: string }> = ({ k, v }) => (
     <td className="py-1 text-right font-medium text-gray-900 dark:text-gray-100">{v}</td>
   </tr>
 );
+
+// 1つの特定行政庁を、庁名・区分・公式URLリンクで表示する。規模分割地点では小規模/大規模の
+// それぞれに scaleLabel（小規模/大規模）を付けて2枚並べる。
+const AuthorityCard: React.FC<{ au?: Authority; scaleLabel?: string; sub?: string }> = ({
+  au,
+  scaleLabel,
+  sub,
+}) => {
+  if (!au) return null;
+  return (
+    <div className="bg-gray-50 dark:bg-gray-700/40 rounded-lg p-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="min-w-0">
+          {scaleLabel ? (
+            <span className="text-[10px] font-semibold text-blue-600 dark:text-blue-400 mr-1">
+              {scaleLabel}
+            </span>
+          ) : null}
+          <span className="text-sm font-bold text-gray-900 dark:text-gray-100">{au.name}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">
+            {AUTHORITY_TYPE_LABEL[au.type] ?? au.type}
+          </span>
+        </div>
+        {au.url ? (
+          <a
+            href={au.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-0.5 text-xs text-blue-500 hover:underline"
+            title={au.url}
+          >
+            公式ページ
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        ) : null}
+      </div>
+      <div className="text-[11px] text-gray-400 mt-0.5">
+        {au.legal_basis}
+        {sub ? ` ・ ${sub}` : ''}
+      </div>
+    </div>
+  );
+};
 
 export default HazardMapApp;

--- a/src/components/hazard/api.ts
+++ b/src/components/hazard/api.ts
@@ -36,6 +36,27 @@ export interface ShoreInfo {
   nearest_lat: number | null;
 }
 
+// 特定行政庁(建築基準法)。区分(type)= 都道府県知事 / 全規模を置く市 / 限定特定行政庁 / 特別区。
+export type AuthorityType = 'prefecture' | 'city_full' | 'city_limited' | 'special_ward';
+export interface Authority {
+  authority_id: string;
+  name: string;
+  type: AuthorityType;
+  legal_basis: string;
+  url: string | null;
+}
+// 単独所管なら all、規模で分かれる地点(限定/特別区)は small(区市町村側)/large(知事側)の両方。
+export interface BuildingAuthority {
+  pref: string | null;
+  split: boolean;
+  all?: Authority; // split=false
+  small?: Authority; // split=true（区市町村長・区長）
+  large?: Authority; // split=true（都道府県知事・都知事）
+  scale_rule?: string;
+  nearest?: boolean; // 区域外で最寄り庁を補完したとき
+  nearest_km?: number;
+}
+
 export interface DesignResult {
   lat: number;
   lng: number;
@@ -43,6 +64,7 @@ export interface DesignResult {
   snow: SnowParams | null;
   seismic: SeismicParams | null;
   shore: ShoreInfo | null;
+  building_authority: BuildingAuthority | null;
   radius_km: number;
   sea_ratio: number;
   land_ratio: number;


### PR DESCRIPTION
Hazard Map のオーバーレイ機能拡張。**PR #32 を取り込み済み**で、以下2つを含みます。

## 1. オーバーレイのカテゴリ化＋ループ切替（旧 #31 本体）
- オーバーレイのアイコンをカテゴリ化し、同じアイコンを押すたびにカテゴリ内の表示を**ループ巡回**。
- 積雪アイコン: `積雪深(連続ラスター) ↔ 積雪地域区分(平12建告1455号の区分ポリゴン)`。区分は隣接が別色になるカテゴリ配色。
- 「オフ」は独立ボタンのまま。複数variantのカテゴリは現在位置をドット表示。

## 2. 特定行政庁（建築基準法）の分布＋所管庁表示（取り込み: #32）
- **都市計画区域カテゴリのサブ表示**として特定行政庁の分布を追加（都市計画区域アイコンで `都市計画区域 ↔ 特定行政庁` をループ切替）。庁の区分(type)で4色に塗り分け、ホバーで庁名。
- 左パネルに「特定行政庁」セクション: 所管庁の**名称・区分・公式URL**。規模で分かれる地点（限定特定行政庁・特別区）は**小規模/大規模の両方**を併記。
- `api.ts` に `DesignResult.building_authority` 型を追加。

## 依存・確認
- データは **jiban-api PR #8（マージ済み・本番稼働）** の `/design/lookup` の `building_authority` と `/design/tiles/authority_zones.pmtiles`。
- Dokploy 自動プレビュー（base=main）で動作確認済み。`tsc` / `eslint` / `build` 通過。

base は `main`。マージで MiniTools 本番へ反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)