### PR TITLE
feat(hazard): 特定行政庁の分布オーバーレイ＋所管庁(URL)表示

### DIFF
--- a/src/components/hazard/HazardMap.tsx
+++ b/src/components/hazard/HazardMap.tsx
@@ -8,7 +8,7 @@ interface LatLng {
   lng: number;
 }
 
-export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth' | 'snow_zones';
+export type ZoneOverlay = 'none' | 'wind' | 'seismic' | 'urban' | 'depth' | 'snow_zones' | 'authority';
 
 interface HazardMapProps {
   center: LatLng; // マーカー＋海率円の中心（地図クリックでも更新される）
@@ -76,6 +76,27 @@ const URBAN_PMTILES = '/api/design/tiles/urban_areas.pmtiles';
 const URBAN_SOURCE_LAYER = 'urban';
 const URBAN_FILL_COLOR = '#9ca3af'; // gray-400
 
+// 特定行政庁(建築基準法)の分布。authority_zones.pmtiles(source-layer='zones')を庁の区分(type)で
+// 4色に塗り分ける。属性は build_authority_geojson.py のフラット属性(p_type/p_name/split/l_name…)。
+const AUTHORITY_PMTILES = '/api/design/tiles/authority_zones.pmtiles';
+const AUTHORITY_SOURCE_LAYER = 'zones';
+// 区分(type)→色。知事=緑 / 建築主事設置市=青 / 限定特定行政庁=橙 / 特別区=紫。
+const AUTHORITY_TYPE_COLOR: maplibregl.ExpressionSpecification = [
+  'match', ['get', 'p_type'],
+  'prefecture', '#66bd63',
+  'city_full', '#3182bd',
+  'city_limited', '#fdae61',
+  'special_ward', '#8856a7',
+  '#bdbdbd',
+];
+// 区分(type)の日本語ラベル（凡例/ホバー用）。
+const AUTHORITY_TYPE_LABEL: Record<string, string> = {
+  prefecture: '都道府県知事',
+  city_full: '建築主事設置市',
+  city_limited: '限定特定行政庁',
+  special_ward: '特別区',
+};
+
 // 地図内オーバーレイ凡例（CSSグラデーション）。地図の塗り色と対応。
 const LEGEND: Record<Exclude<ZoneOverlay, 'none'>, { title: string; grad: string; min: string; max: string }> = {
   wind: {
@@ -112,6 +133,15 @@ const LEGEND: Record<Exclude<ZoneOverlay, 'none'>, { title: string; grad: string
       'linear-gradient(to right,#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,' +
       '#8c564b,#e377c2,#17becf,#bcbd22,#393b79)',
     min: '区分ごとに配色',
+    max: '',
+  },
+  authority: {
+    title: '特定行政庁（建築基準法）',
+    // 庁の区分で色分け（知事=緑 / 主事設置市=青 / 限定=橙 / 特別区=紫）の4色ハードストップ。
+    grad:
+      'linear-gradient(to right,#66bd63 0 25%,#3182bd 25% 50%,' +
+      '#fdae61 50% 75%,#8856a7 75% 100%)',
+    min: '知事 / 市 / 限定 / 特別区',
     max: '',
   },
 };
@@ -264,6 +294,9 @@ const HazardMap: React.FC<HazardMapProps> = ({
     if (map.getLayer('zones-urban-fill')) {
       map.setLayoutProperty('zones-urban-fill', 'visibility', kind === 'urban' ? 'visible' : 'none');
     }
+    if (map.getLayer('zones-authority-fill')) {
+      map.setLayoutProperty('zones-authority-fill', 'visibility', kind === 'authority' ? 'visible' : 'none');
+    }
     if (map.getLayer('zones-depth-fill')) {
       map.setLayoutProperty('zones-depth-fill', 'visibility', kind === 'depth' ? 'visible' : 'none');
     }
@@ -355,6 +388,20 @@ const HazardMap: React.FC<HazardMapProps> = ({
         'source-layer': URBAN_SOURCE_LAYER,
         layout: { visibility: 'none' },
         paint: { 'fill-color': URBAN_FILL_COLOR, 'fill-opacity': 0.45 },
+      });
+
+      // 特定行政庁（建築基準法）の分布。庁の区分(type)で4色に塗り分け。
+      map.addSource('zones-authority', {
+        type: 'vector',
+        url: `pmtiles://${origin}${AUTHORITY_PMTILES}`,
+      });
+      map.addLayer({
+        id: 'zones-authority-fill',
+        type: 'fill',
+        source: 'zones-authority',
+        'source-layer': AUTHORITY_SOURCE_LAYER,
+        layout: { visibility: 'none' },
+        paint: { 'fill-color': AUTHORITY_TYPE_COLOR, 'fill-opacity': 0.5 },
       });
 
       map.addSource('circle', { type: 'geojson', data: EMPTY_FC });
@@ -451,6 +498,19 @@ const HazardMap: React.FC<HazardMapProps> = ({
         if (fs.length) {
           const p = fs[0].properties || {};
           setHover(`積雪区分: 第${p.zone}区 (α${p.alpha} β${p.beta} γ${p.gamma})`);
+        } else {
+          setHover(null);
+        }
+        return;
+      }
+      if (ov === 'authority') {
+        const fs = map.queryRenderedFeatures(e.point, { layers: ['zones-authority-fill'] });
+        if (fs.length) {
+          const p = fs[0].properties || {};
+          const typeLabel = AUTHORITY_TYPE_LABEL[p.p_type as string] ?? '';
+          // 規模分割地点は小規模側(主たる庁)を表示し、大規模側を併記。
+          const large = p.split ? `／大規模:${p.l_name}` : '';
+          setHover(`特定行政庁: ${p.p_name}${typeLabel ? `（${typeLabel}）` : ''}${large}`);
         } else {
           setHover(null);
         }

--- a/src/components/hazard/HazardMapApp.tsx
+++ b/src/components/hazard/HazardMapApp.tsx
@@ -1,9 +1,17 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Search, MapPin, TriangleAlert, Snowflake, Wind, Activity, Building2, EyeOff } from 'lucide-react';
+import { Search, MapPin, TriangleAlert, Snowflake, Wind, Activity, Building2, EyeOff, ExternalLink } from 'lucide-react';
 import HazardMap from './HazardMap';
 import type { ZoneOverlay } from './HazardMap';
 import { fetchDesign, fetchElevation, geocode, reverseGeocode, snowDepthCm } from './api';
-import type { DesignResult } from './api';
+import type { DesignResult, Authority, AuthorityType } from './api';
+
+// 特定行政庁の区分(type)の日本語ラベル。
+const AUTHORITY_TYPE_LABEL: Record<AuthorityType, string> = {
+  prefecture: '都道府県知事',
+  city_full: '建築主事設置市',
+  city_limited: '限定特定行政庁',
+  special_ward: '特別区',
+};
 
 // 地図上のオーバーレイ切替アイコン。カテゴリごとに1つのアイコンを持ち、同じアイコンを
 // 押すたびに category 内の variant をループで巡回する（例: 積雪アイコン → 積雪深 →
@@ -28,7 +36,16 @@ const OVERLAY_CATEGORIES: OverlayCategory[] = [
       { val: 'snow_zones', label: '積雪地域区分' },
     ],
   },
-  { key: 'urban', Icon: Building2, label: '都市計画区域', variants: [{ val: 'urban', label: '都市計画区域' }] },
+  {
+    key: 'urban',
+    Icon: Building2,
+    label: '都市計画区域',
+    // 押すたびに 都市計画区域(外形) ↔ 特定行政庁(建築基準法の所管庁分布) をループ切替。
+    variants: [
+      { val: 'urban', label: '都市計画区域' },
+      { val: 'authority', label: '特定行政庁' },
+    ],
+  },
 ];
 
 interface HazardMapAppProps {
@@ -158,6 +175,7 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
   const shore = design?.shore ?? null;
   const seaRatio = design?.sea_ratio ?? null;
   const landRatio = design?.land_ratio ?? null;
+  const building = design?.building_authority ?? null;
 
   // 標高が取れる＝陸とみなす。区域ポリゴン外(海岸線変化の埋立地等)でも、陸なら
   // 最寄り区分(nearest)を採用して計算する。陸と判定できなければ採用しない＝海上扱い。
@@ -183,7 +201,7 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
           Hazard Map
         </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          地図をクリック、または検索ボックスに住所・地名か「緯度,経度」を入力すると、その地点の海率・標高と、建築基準法告示の積雪荷重係数・基準風速・地震地域係数・積雪深を表示します。
+          地図をクリック、または検索ボックスに住所・地名か「緯度,経度」を入力すると、その地点の海率・標高と、建築基準法告示の積雪荷重係数・基準風速・地震地域係数・積雪深、所管する特定行政庁を表示します。
         </p>
       </div>
 
@@ -359,6 +377,38 @@ const HazardMapApp: React.FC<HazardMapAppProps> = ({ onSuccess, onError }) => {
                   </p>
                 )}
               </div>
+
+              {/* 特定行政庁（建築基準法） */}
+              <div>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">
+                  特定行政庁（建築基準法）
+                </h3>
+                {building && (building.all || building.small) ? (
+                  <div className="space-y-2">
+                    {building.split ? (
+                      <>
+                        <AuthorityCard scaleLabel="小規模" sub="法6条1項一〜三号以外の規模" au={building.small} />
+                        <AuthorityCard scaleLabel="大規模" sub="法6条1項一〜三号の規模" au={building.large} />
+                        <p className="text-[11px] text-gray-400">
+                          建築物の規模で所管が分かれる地点です（限定特定行政庁・特別区）。規模の境界は施行令148条/149条の現行条文によります。
+                        </p>
+                      </>
+                    ) : (
+                      <AuthorityCard au={building.all} />
+                    )}
+                    {building.nearest ? (
+                      <p className="text-[11px] text-amber-600 dark:text-amber-500">
+                        区域外のため最寄りの庁を表示（約{building.nearest_km?.toFixed(1)}km）。
+                      </p>
+                    ) : null}
+                    <p className="text-[11px] text-gray-400">
+                      庁区分: 令和7年4月1日現在（全国建築審査会協議会）。URLは参考値のため最終確認は各庁の窓口で。
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-400">取得できませんでした（海上など）</p>
+                )}
+              </div>
             </div>
           </div>
 
@@ -496,5 +546,48 @@ const Row: React.FC<{ k: string; v: string }> = ({ k, v }) => (
     <td className="py-1 text-right font-medium text-gray-900 dark:text-gray-100">{v}</td>
   </tr>
 );
+
+// 1つの特定行政庁を、庁名・区分・公式URLリンクで表示する。規模分割地点では小規模/大規模の
+// それぞれに scaleLabel（小規模/大規模）を付けて2枚並べる。
+const AuthorityCard: React.FC<{ au?: Authority; scaleLabel?: string; sub?: string }> = ({
+  au,
+  scaleLabel,
+  sub,
+}) => {
+  if (!au) return null;
+  return (
+    <div className="bg-gray-50 dark:bg-gray-700/40 rounded-lg p-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="min-w-0">
+          {scaleLabel ? (
+            <span className="text-[10px] font-semibold text-blue-600 dark:text-blue-400 mr-1">
+              {scaleLabel}
+            </span>
+          ) : null}
+          <span className="text-sm font-bold text-gray-900 dark:text-gray-100">{au.name}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">
+            {AUTHORITY_TYPE_LABEL[au.type] ?? au.type}
+          </span>
+        </div>
+        {au.url ? (
+          <a
+            href={au.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-0.5 text-xs text-blue-500 hover:underline"
+            title={au.url}
+          >
+            公式ページ
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        ) : null}
+      </div>
+      <div className="text-[11px] text-gray-400 mt-0.5">
+        {au.legal_basis}
+        {sub ? ` ・ ${sub}` : ''}
+      </div>
+    </div>
+  );
+};
 
 export default HazardMapApp;

--- a/src/components/hazard/api.ts
+++ b/src/components/hazard/api.ts
@@ -36,6 +36,27 @@ export interface ShoreInfo {
   nearest_lat: number | null;
 }
 
+// 特定行政庁(建築基準法)。区分(type)= 都道府県知事 / 全規模を置く市 / 限定特定行政庁 / 特別区。
+export type AuthorityType = 'prefecture' | 'city_full' | 'city_limited' | 'special_ward';
+export interface Authority {
+  authority_id: string;
+  name: string;
+  type: AuthorityType;
+  legal_basis: string;
+  url: string | null;
+}
+// 単独所管なら all、規模で分かれる地点(限定/特別区)は small(区市町村側)/large(知事側)の両方。
+export interface BuildingAuthority {
+  pref: string | null;
+  split: boolean;
+  all?: Authority; // split=false
+  small?: Authority; // split=true（区市町村長・区長）
+  large?: Authority; // split=true（都道府県知事・都知事）
+  scale_rule?: string;
+  nearest?: boolean; // 区域外で最寄り庁を補完したとき
+  nearest_km?: number;
+}
+
 export interface DesignResult {
   lat: number;
   lng: number;
@@ -43,6 +64,7 @@ export interface DesignResult {
   snow: SnowParams | null;
   seismic: SeismicParams | null;
   shore: ShoreInfo | null;
+  building_authority: BuildingAuthority | null;
   radius_km: number;
   sea_ratio: number;
   land_ratio: number;


### PR DESCRIPTION
## 概要
Hazard Map に**特定行政庁（建築基準法）**を追加します。
1. **都市計画区域カテゴリのサブ表示**として特定行政庁の分布を地図にオーバーレイ。都市計画区域のアイコンを押すたびに `都市計画区域 ↔ 特定行政庁` をループ切替。
2. 指定地点を**所管する特定行政庁**を左パネルに表示（名称・区分・**公式URLリンク**付き）。規模で所管が分かれる地点（限定特定行政庁・特別区）は**小規模/大規模の両方**を併記。

## 表示
- 分布は庁の**区分(type)で4色**に塗り分け（知事=緑 / 建築主事設置市=青 / 限定特定行政庁=橙 / 特別区=紫）。ホバーで庁名・区分（分割地点は大規模側も併記）。
- 左パネル「特定行政庁」セクション: 各庁を `庁名 + 区分 + 公式ページリンク` で表示。分割地点は小規模/大規模の2枚。区域外は最寄り庁＋注記。

## 変更
- `api.ts`: `DesignResult.building_authority`（`{split, all | small+large, *.url}`）型を追加。
- `HazardMap.tsx`: `authority` オーバーレイ（`/api/design/tiles/authority_zones.pmtiles`・type別配色）＋ホバー＋凡例。
- `HazardMapApp.tsx`: 都市計画区域カテゴリに `特定行政庁` variant を追加、左パネルに `AuthorityCard` セクション。

## 依存・注意
- ⚠️ **base は `feat/hazard-snow-zone-overlay`（PR #31）**。本機能は #31 で入れた「カテゴリ＝アイコン連打でサブ表示を巡回」する仕組みの上に乗ります。#31 マージ後に base を `main` へ付け替えます。
- ⚠️ **データは jiban-api PR #8 に依存**（`/design/lookup` の `building_authority` と `/design/tiles/authority_zones.pmtiles`）。Dokploy で jiban-api をデプロイ後に実データが出ます。Vercelプレビュー(api無)では分布・所管庁は出ません。

## 確認
`tsc --noEmit` ✅ / `eslint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)