### PR TITLE
fix(boring): XML取得失敗を握りつぶさず理由を表示、log中継の302を素通し

### DIFF
--- a/server.js
+++ b/server.js
@@ -137,7 +137,10 @@ app.use('/api/ngi', async (req, res) => {
     const fwd = { accept: req.headers['accept'] || '*/*' }
     if (req.headers['range']) fwd['range'] = req.headers['range']
     if (req.headers['if-none-match']) fwd['if-none-match'] = req.headers['if-none-match']
-    const upstream = await fetch(target, { method: req.method, headers: fwd })
+    // 画像型柱状図(/ngi/proxy/*/log/*)は jiban-api が公開ビューアの閲覧ページへ 302 を返す。
+    // fetch は既定でリダイレクトを追ってしまい、相対パスのCSS/画像が /api/ngi 配下を指す
+    // 壊れたHTMLになる。redirect:'manual' で 302 のまま Location をブラウザへ返す。
+    const upstream = await fetch(target, { method: req.method, headers: fwd, redirect: 'manual' })
     res.status(upstream.status)
     for (const h of [
       'content-type',
@@ -146,6 +149,7 @@ app.use('/api/ngi', async (req, res) => {
       'accept-ranges',
       'etag',
       'last-modified',
+      'location',
     ]) {
       const v = upstream.headers.get(h)
       if (v) res.setHeader(h, v)

--- a/src/components/boring/BoringDataApp.tsx
+++ b/src/components/boring/BoringDataApp.tsx
@@ -89,7 +89,8 @@ const BoringDataApp: React.FC<BoringDataAppProps> = ({ onSuccess, onError }) => 
             setBoringData(data);
           } catch (e) {
             console.error('Failed to fetch boring data:', e);
-            onError?.('ボーリングデータの取得に失敗しました');
+            // 公開元にデータが無い場合など、中継プロキシが返した理由をそのまま見せる。
+            onError?.(e instanceof Error && e.message ? e.message : 'ボーリングデータの取得に失敗しました');
             setBoringData(null);
           }
         } else if (pdfUrl) {

--- a/src/components/boring/BoringLogViewer.tsx
+++ b/src/components/boring/BoringLogViewer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { X, Download, FileText, Droplet, Calendar, Building2, Hash, ExternalLink, Mountain, Code, Database } from 'lucide-react';
 import type { BoringData, MLITSearchResult } from './types';
+import { describeFetchFailure } from './api';
 
 interface BoringLogViewerProps {
   data: BoringData | null;
@@ -15,6 +16,9 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
   loading,
   onClose,
 }) => {
+  // XMLダウンロード失敗の理由（公開元にデータが無い等）をボタン下に出す。
+  const [downloadError, setDownloadError] = React.useState<string | null>(null);
+
   if (!selectedResult) {
     return null;
   }
@@ -73,9 +77,15 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
   // 同一オリジンの中継URL(/api/ngi, /api/tokyo)をBlob化してdownload属性で保存する。
   // 取得に失敗した場合は従来どおり新規タブで開く（フォールバック）。
   const handleDownload = async (url: string, filename: string) => {
+    setDownloadError(null);
     try {
       const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      // 公開元にデータが無い等（中継プロキシが404）。HTMLエラーページを .xml として
+      // 保存させてしまわないよう、ここで止めて理由を表示する。
+      if (!response.ok) {
+        setDownloadError(await describeFetchFailure(response));
+        return;
+      }
       const blob = await response.blob();
       const objectUrl = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -167,6 +177,9 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
                 <Download className="w-4 h-4" />
                 XMLファイルをダウンロード
               </button>
+            )}
+            {downloadError && (
+              <p className="w-full text-sm text-red-600 dark:text-red-400">{downloadError}</p>
             )}
           </div>
         )}

--- a/src/components/boring/api.ts
+++ b/src/components/boring/api.ts
@@ -730,6 +730,21 @@ export function parseBoringXML(xmlString: string, id: string, location: GeoLocat
 }
 
 // XMLファイルのフェッチと解析
+// 中継プロキシ(jiban-api)のエラー本文は {"detail": "..."} のJSON。公開元にデータが無い
+// (404)場合はその説明をそのままユーザーに見せたいので、本文があれば拾って文言にする。
+export async function describeFetchFailure(response: Response): Promise<string> {
+  let detail = '';
+  try {
+    const body = await response.clone().json();
+    if (body && typeof body.detail === 'string') detail = body.detail;
+  } catch {
+    // JSONでなければ本文は使わない（HTMLエラーページ等）
+  }
+  if (detail) return detail;
+  if (response.status === 404) return '公開元にこのデータがありません（404）';
+  return `取得に失敗しました: ${response.status} ${response.statusText}`;
+}
+
 export async function fetchAndParseBoringData(
   xmlUrl: string,
   id: string,
@@ -746,7 +761,7 @@ export async function fetchAndParseBoringData(
     const response = await fetch(fetchUrl);
 
     if (!response.ok) {
-      throw new Error(`XMLファイルの取得に失敗: ${response.status} ${response.statusText}`);
+      throw new Error(await describeFetchFailure(response));
     }
 
     // Shift_JIS エンコーディングで読み込み


### PR DESCRIPTION
## 背景
「XMLファイルをダウンロード」が XML ではなく `Error Code 404` の HTML を `.xml` として
保存する不具合の、フロント側の対応。**根本原因と本体の修正は ymzkd/jiban-api#9**
（中継プロキシの上流 `publicweb.ngic.or.jp` が閉鎖されていたため、
`www.kunijiban.pwri.go.jp` へ移行し、上流の HTTP200+HTMLエラーページを 404 に変換）。

このPR単体ではダウンロードは直らない（jiban-api#9 のデプロイが必要）。ここでは
「壊れたファイルを黙って保存させない」「新しい 302 応答を正しく扱う」の2点を入れる。

## 変更
- **`server.js` `/api/ngi`**: `redirect: 'manual'` + `location` ヘッダ転送。
  jiban-api が画像型柱状図で公開ビューアの閲覧ページへ 302 を返すようになるが、
  Node の `fetch` は既定でリダイレクトを追ってしまい、相対パスの CSS/画像が
  `/api/ngi` 配下を指す壊れた HTML になる。
- **`BoringLogViewer`**: ダウンロード失敗時に新規タブで JSON を開くのをやめ、
  プロキシが返した理由（`{"detail": "..."}`）をボタン下に赤字で表示。
  HTMLエラーページが `.xml` として保存されることも防げる。
- **`api.ts` `describeFetchFailure()`**: 応答本文の `detail` を拾って文言化する共通処理。
- **`BoringDataApp`**: 詳細（インライン柱状図）取得の失敗も、汎用文言ではなく
  同じ理由文をトーストに出す。

## 確認
- `npm run build`（`tsc -b` 含む）通過、変更ファイルの eslint 通過。
- プレビューでの実挙動確認は jiban-api#9 デプロイ後。
  現状の本番 jiban-api に対しては「取得に失敗しました: 502 ...」等が表示される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfdGUnmPdao56vVoJHPvDN