### PR TITLE
feat(boring): 外部ビューアのリンクをAPI提供値にする

### DIFF
--- a/src/components/boring/BoringLogViewer.tsx
+++ b/src/components/boring/BoringLogViewer.tsx
@@ -69,6 +69,14 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
 
   const ngiId = getNGIId();
 
+  // 外部ビューアのURL。上流によって踏めるURLが違うのでAPI/タイルが組んだ値を使う。
+  // 未提供（古いキャッシュ等）の場合だけ、従来どおり KuniJiban のURLを組み立てる。
+  const viewUrl =
+    selectedResult.metadata?.['NGI:link_boring_view'] ||
+    (ngiId
+      ? `https://www.kunijiban.pwri.go.jp/viewer/refer/?data=boring&type=view&id=${ngiId}`
+      : undefined);
+
   // ファイル名に使えない文字を除去
   const sanitizeFileName = (name: string): string =>
     name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'boring';
@@ -140,7 +148,7 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
           PDF柱状図のみの地点(港湾など)でもここから柱状図PDFを開ける。 */}
       {!loading &&
         (selectedResult.metadata?.['NGI:link_boring_pdf'] ||
-          ngiId ||
+          viewUrl ||
           selectedResult.metadata?.['NGI:link_boring_xml']) && (
           <div className="flex flex-wrap gap-2 px-4 pt-4">
             {selectedResult.metadata?.['NGI:link_boring_pdf'] && (
@@ -155,9 +163,9 @@ const BoringLogViewer: React.FC<BoringLogViewerProps> = ({
               </a>
             )}
             {/* 外部ビューア（PDF柱状図ボタンがある場合は同じ柱状図なので出さない） */}
-            {ngiId && !selectedResult.metadata?.['NGI:link_boring_pdf'] && (
+            {viewUrl && !selectedResult.metadata?.['NGI:link_boring_pdf'] && (
               <a
-                href={`https://www.kunijiban.pwri.go.jp/viewer/refer/?data=boring&type=view&id=${ngiId}`}
+                href={viewUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors text-sm font-medium"

--- a/src/components/boring/MapView.tsx
+++ b/src/components/boring/MapView.tsx
@@ -14,7 +14,7 @@ const SELECTED_COLOR = '#2563eb';
 // 低ズーム=ヒートマップ(密度)、中〜高ズーム=ソース色分けの円。クリックで個別地点を選択。
 // 地点データの取得はタイル側に寄せたので、ビューポート連動のAPI取得は行わない。
 // ?v= はタイル再生成時のキャッシュバスト用（中身が変わったら上げる）。
-const PMTILES_URL = '/api/ngi/tiles/points.pmtiles?v=2';
+const PMTILES_URL = '/api/ngi/tiles/points.pmtiles?v=3';
 const POINTS_LAYER = 'points'; // tippecanoe -l points
 
 interface MapViewProps {

--- a/src/components/boring/MapView.tsx
+++ b/src/components/boring/MapView.tsx
@@ -31,6 +31,7 @@ interface TileProps {
   title?: string;
   xml_url?: string;
   log_url?: string; // PDF型柱状図のときだけ存在(画像型は無し)
+  view_url?: string; // 外部ビューアで柱状図を開くURL
   soil_xml_url?: string;
   soil_log_url?: string;
 }
@@ -53,12 +54,14 @@ function featureToResult(p: TileProps, lng: number, lat: number): MLITSearchResu
   const ngiId = (p.xml_url || p.log_url || '').match(/\/(\d+)$/)?.[1];
   return {
     id: p.id ?? `${lng},${lat}`,
-    title: p.title ?? p.id ?? '',
+    // publicweb 固有の点は調査名を持たない。XMLを取得した時点で本来の調査名に置き換わる。
+    title: p.title ?? '(調査名未取得)',
     source: isTokyo ? ('tokyo' as const) : ('mlit' as const),
     metadata: {
       'NGI:link_boring_xml': p.xml_url,
       // log_url は PDF型のみ存在。画像型では undefined になり「PDF柱状図を表示」は出さない。
       'NGI:link_boring_pdf': p.log_url,
+      'NGI:link_boring_view': p.view_url,
       ...(p.source_name ? { 'NGI:source_name': p.source_name } : {}),
       ...(ngiId ? { 'NGI:id': ngiId } : {}),
     },

--- a/src/components/boring/api.ts
+++ b/src/components/boring/api.ts
@@ -505,6 +505,7 @@ interface NgiSearchItem {
   boring_length?: number;
   xml_url: string | null;   // 同一オリジン中継 /api/ngi/proxy/boring/xml/<id>（無い場合 null）
   log_url: string | null;   // 柱状図(PDF/PNG)中継、または港湾の直リンクPDF
+  view_url?: string | null; // 外部ビューアで柱状図を開くURL
   has_soiltest: boolean;
   soiltest_xml_url?: string;
   soiltest_log_url?: string;
@@ -527,6 +528,7 @@ function mapNgiItem(item: NgiSearchItem): MLITSearchResult {
       // 詳細取得は共通の link_boring_xml 経路（同一オリジンの中継プロキシ）に乗せる。
       'NGI:link_boring_xml': item.xml_url ?? undefined,
       'NGI:link_boring_pdf': item.log_url ?? undefined,
+      'NGI:link_boring_view': item.view_url ?? undefined,
     },
     location: { lat: item.lat, lng: item.lng },
     datasetName: '国土地盤情報(NGI)',

--- a/src/components/boring/types.ts
+++ b/src/components/boring/types.ts
@@ -37,6 +37,9 @@ export interface MLITSearchResult {
     'NGI:address'?: string;
     'NGI:survey_finish'?: string;
     'NGI:link_boring_xml'?: string;
+    // 「外部サイトで柱状図を表示」で開くURL。上流(KuniJiban / publicweb)ごとに
+    // 踏めるURLが違うのでAPI/タイル側で組み立てたものを使う。
+    'NGI:link_boring_view'?: string;
     'NGI:boring_xml_version'?: string;
     'NGI:boring_elevation'?: string;
     [key: string]: string | undefined;  // 他のメタデータフィールド


### PR DESCRIPTION
## 背景
NGIC の公開サイト publicweb は ID を9桁に振り直しており、DPFが配る旧IDでは 404 になる。
一方 KuniJiban は旧IDのまま。**上流が2つになり、レコードごとに踏めるURLが違う**ため、
フロントで KuniJiban のURLをハードコードしていた箇所を、API/タイルが提供する値に置き換える。

サーバ側の対応は ymzkd/jiban-api#10。

## なぜフロントで組み立てられないか
publicweb の `/viewer/refer/` は **Referer が publicweb 配下でないと 403**（実測）。
`rel="noreferrer"` で Referer を落としても 403 なので、外部サイトからは直接踏めない。
ガードの無い `NGICViewer/index.php?xml=<パス>` へ中継プロキシが 302 する形にしたため、
どのURLを開くかはサーバ側でしか決められない。

| 上流 | 「外部サイトで柱状図を表示」が開くURL |
|---|---|
| KuniJiban (class 1) | `kunijiban.../viewer/refer/?data=boring&type=view&id=<旧ID>`（直リンク可） |
| publicweb (class 2/3) | `/api/ngi/proxy/boring/log/<旧ID>` → 302 → `NGICViewer/index.php?xml=…` |

## 変更
- `types.ts` / `MapView.tsx` / `api.ts` … `NGI:link_boring_view`（`view_url`）を追加
- `BoringLogViewer.tsx` … ハードコードURLを廃止。未提供時のみ従来の KuniJiban URL にフォールバックするので、**サーバ側が未デプロイでも現状どおり動く**
- publicweb 固有の点は調査名を持たない（`markers.php` が id・座標・class しか返さないため）ので
  「(調査名未取得)」を表示。XML を取得した時点で本来の調査名に置き換わる

## 確認
`npm run build`（tsc 含む）通過、変更ファイルの eslint 通過。
プレビューは本番の jiban-api を見るため、このPR単体では従来どおりの表示になる（フォールバック動作の確認になる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfdGUnmPdao56vVoJHPvDN